### PR TITLE
💄 Fix style in production env

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -137,7 +137,7 @@ const config = {
       announcementBar: {
         id: 'rename_announcement',
         content:
-          '⚠️ We are currently undergoing a rename from <a rel="noopener noreferrer" href="https://docs.qhub.dev/">QHUb</a> to Nebari ⚠️ </br>You might see some references to <b>QHub</b> mainly in the context of commands or installation/setup in the meantime.',
+          '⚠️ We are currently undergoing a rename from <a rel="noopener noreferrer" href="https://docs.qhub.dev/">QHub</a> to Nebari ⚠️ </br>You might see some references to <b>QHub</b> mainly in the context of commands or installation/setup in the meantime.',
         isCloseable: false,
       },
       footer: {

--- a/docs/src/scss/core.scss
+++ b/docs/src/scss/core.scss
@@ -131,12 +131,6 @@ a {
 .card {
   background-color: transparent;
   border-radius: var(--ifm-global-radius);
-  // for now a workaround to have all cards the same height
-  height: 100%;
-}
-.row {
-  // for now a workaround to have all cards the same height
-  align-items: stretch;
 }
 
 .cardContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module {
@@ -146,13 +140,13 @@ a {
   transition-property: box-shadow;
 }
 
-.cardContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module:hover,
-.cardContainer_woeA:hover {
+.cardContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module:hover {
   border: 1px solid var(--ifm-color-emphasis-300) !important;
   border-bottom: 3px solid var(--secondary-nebari) !important;
   box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
 }
 
+[data-theme="dark"] a,
 a.card {
   text-decoration: none;
   color: var(--ifm-color-content);
@@ -168,19 +162,9 @@ a.card {
   background-color: var(--ifm-hover-overlay);
 }
 
-.text--truncate {
+.text--truncate.cardTitle_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module {
   white-space: pre-wrap;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2; /* number of lines to show */
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-[data-theme="dark"] a,
-a.card {
-  color: var(--ifm-color-content);
-  text-decoration: none;
+  -webkit-line-clamp: 2;
 }
 
 // ==============================================================================

--- a/docs/src/scss/core.scss
+++ b/docs/src/scss/core.scss
@@ -131,6 +131,12 @@ a {
 .card {
   background-color: transparent;
   border-radius: var(--ifm-global-radius);
+  // for now a workaround to have all cards the same height
+  height: 100%;
+}
+.row {
+  // for now a workaround to have all cards the same height
+  align-items: stretch;
 }
 
 .cardContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module {
@@ -140,7 +146,8 @@ a {
   transition-property: box-shadow;
 }
 
-.cardContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module:hover {
+.cardContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module:hover,
+.cardContainer_woeA:hover {
   border: 1px solid var(--ifm-color-emphasis-300) !important;
   border-bottom: 3px solid var(--secondary-nebari) !important;
   box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
@@ -161,9 +168,19 @@ a.card {
   background-color: var(--ifm-hover-overlay);
 }
 
-.text--truncate.cardTitle_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocCard-styles-module {
+.text--truncate {
   white-space: pre-wrap;
-  -webkit-line-clamp: 2;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* number of lines to show */
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+[data-theme="dark"] a,
+a.card {
+  color: var(--ifm-color-content);
+  text-decoration: none;
 }
 
 // ==============================================================================

--- a/docs/src/theme/components/admonitions.scss
+++ b/docs/src/theme/components/admonitions.scss
@@ -7,10 +7,10 @@
 .admonition:not(.alert) {
   color: var(--ifm-color-on-background);
   border-radius: var(--ifm-global-radius);
-  border-bottom: 1 solid;
   border-top: 0 solid;
   border-right: 0 solid;
   border-left: 10px solid;
+  border-bottom: none;
 
   /* For default Admonition */
   background-color: var(--ifm-admonition-background-color);


### PR DESCRIPTION
- :lipstick: Fix style in production env
- :pencil2: Fix banner typo

I recently did an overhaul to update the docs theme (#145).
I oversaw that `admonition` has different classes for production and development. This PR fixes style inconsistencies between these two. 

And ensures that the cards are now correctly truncated AND the same height regardless of the content displayed like so:


![Nebari_Tutorials___Nebari](https://user-images.githubusercontent.com/23552331/193569657-62bb2b29-8320-45b2-914b-cfcb4474b9e3.png)


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #146 

## What does this implement/fix?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

