### PR TITLE
Fix alignment of logos on homepage

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -298,6 +298,7 @@ height as the column of logos to the right */
     grid-template-columns: 150px 150px;
     grid-template-rows: auto auto;
     row-gap: 1em;
+    justify-content: center;
   }
 
   .integrationsItem:nth-child(2n) {


### PR DESCRIPTION
Center logos under Integrations section below Docusaurus mobile breakpoint:
https://docusaurus.io/docs/styling-layout#mobile-view

To test:

1. Go to home page preview URL
2. Scroll to section "Integrations"
3. Squeeze viewport below 996px wide (or simulate mobile phone view via your browser's dev tools)
4. Observe that the grid of logos is centered horizontally
