### PR TITLE
ENH - Add PR labels rationale

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   # Python
   # Autoformat: Python code, syntax patterns are modernized
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.3.0
     hooks:
       - id: pyupgrade
         args:
@@ -37,7 +37,7 @@ repos:
 
   # Lint: Python code
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: ["--builtins=c"]
@@ -52,7 +52,7 @@ repos:
 
   # Markdown, json, toml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
         types: [markdown, mdx, json, toml]
@@ -60,7 +60,7 @@ repos:
 
   # Misc...
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
     hooks:
       # Autoformat: Makes sure files end in a newline and only a newline

--- a/docs/docs/community/maintainers/github-conventions.md
+++ b/docs/docs/community/maintainers/github-conventions.md
@@ -6,10 +6,12 @@ id: github-conventions
 
 This page describes some common conventions and guidelines that we follow in all of our GitHub repositories within the `nebari-dev` organization.
 
-## Issue labels
+## GitHub labels for issues and pull requests
 
-There are a few issue labels that we use to provide key metadata in our issues and pull requests.
+There are a few GitHub labels that we use to provide key metadata in our issues and pull requests.
 These are added to all `nebari-dev/` repositories, and share the same meaning across each of them.
+
+Issues and pull requests are classified by having a [`type`](#issue-type) label and a number of optional labels such as [`area`](#area-tag) or [`impact`](#issue-impact).
 
 :::note
 Repositories may define their own labels in addition to the ones described here to better reflect the areas
@@ -21,13 +23,15 @@ and scope of the project.
 **REQUIRED :pushpin:**
 
 **Issue type** determines the kind of issue and implies what sorts of actions must be taken to close it.
+**All issues must be assigned a type label as soon as possible.**
 Issue types are mutually-exclusive - **there may only be one issue type per issue**.
 
 There are a few issue types that are defined for all repositories, for example:
 
-- ![type: enhancement 💅🏼](https://img.shields.io/badge/-type:enhancement%20💅🏼-9D73D9.svg): an incremental improvement to something
-- ![type: bug 🐛](https://img.shields.io/badge/-type:bug%20🐛-9D73D9.svg): a problem that needs to be fixed
-- ![type: maintenance 🛠](https://img.shields.io/badge/-type:maintenance%20🛠-9D73D9.svg): regular maintenance and upkeep
+- `type: enhancement 💅🏼`: an incremental improvement to something
+- `type: bug 🐛`: a problem that needs to be fixed
+- `type: maintenance 🛠`: regular maintenance and upkeep
+- `type: discussion 💬`: discussion of general questions, ideas and so on
 
 In addition, other repositories may use repository-specific types, with the caveat that **all issues must still only have one `type` label**.
 
@@ -46,9 +50,9 @@ The impact should be proportional to a combination of:
 
 These are the impact labels for our issues:
 
-![impact: high](https://img.shields.io/badge/-impact:%20high-F2A29B.svg)
-![impact: medium](https://img.shields.io/badge/-impact:%20medium-F2A29B.svg)
-![impact: low](https://img.shields.io/badge/-impact:%20low-F2A29B.svg)
+- `impact: high 🟥`
+- `impact: medium 🟨`
+- `impact: low 🟩`
 
 #### Categorizing impact
 
@@ -80,9 +84,57 @@ They are highly repository-specific, optional, and non-exclusive (so issues may 
 
 Here are some example tags:
 
-- ![area: documentation 📖](https://img.shields.io/badge/-area:%20documentation%20📖-6FB7BF.svg): related to documentation in a repository
-- ![area: CI 👷🏽‍♀️](https://img.shields.io/badge/-area:%20ci%20👷🏽‍♀️-6FB7BF.svg): related to continuous integration/deployment
-- ![area: design 🎨](https://img.shields.io/badge/-area:%20design%20🎨-6FB7BF.svg): related to design items including UX/UI and graphic design
+- `area: documentation 📖`: related to documentation in a repository
+- `area: CI 👷🏽‍♀️`: related to continuous integration/deployment
+- `area: design 🎨`: related to design items including UX/UI and graphic design
+
+### Needs labels
+
+**OPTIONAL**
+
+These labels are used to denote what sort of action is needed to resolve an issue or move a pull request forward.
+
+- `needs: discussion 💬`: this issue needs to be discussed in a meeting or in a GitHub issue
+- `needs: follow-up 📫`: someone in the team needs to follow up on this issue or with another stakeholder
+- `needs: review 👀`: this issue needs to be reviewed by a team member
+- `needs: triage 🚦`: this issue needs to be triaged by a team member
+- `needs: investigation 🔍`: this issue needs to be investigated by a team member, often used when an issue was submitted without enough information or reproduction steps
+- `needs: changes 🧱`: this pull request has been reviewed and changes have been requested
+- `needs: tests ✅`: tests need to be added or updated to close this pull request
+- `needs: documentation 📖`: documentation needs to be added or updated to close this pull request
+- `needs: PR 📬`: this issue needs to be worked on, usually as a pull request
+
+### Other labels
+
+A few labels exist to denote particular situations:
+
+- `Close?`: to denote an issue that might need closing, either because the discussion has dried out or there are no concrete follow-up actions
+- `DO-NOT-MERGE`: to denote a PR that should not be merged yet
+- `good first issue`: these issues represents self-contained work that would make a good introduction to project development for a new contributor
+- `Roadmap 🚀`: this issue is part of the project roadmap
+
+## Pull requests
+
+Pull requests are usually associated with or linked to issues. The natural path is to start with an issue and move onto a pull request for resolution.
+But sometimes a new pull request is created without an associated issue.
+In such cases a new issue should be created for that pull request to engage people in a general discussion, not the technical review which is performed in the pull request itself.
+
+If the PR does not need a discussion (trivial fixes, tasks, and so on), the opening of an associated issue may be skipped, but the pull request must be labeled accordingly.
+
+We use mutually exclusive GitHub labels with the prefix`status:` to classify PR's.
+
+- `status: abandoned 🗑`: this pull request has not seen activity in a while (at least a month)
+- `status: stale 🥖`: a "stale" pull request is one that is no longer up to date with the main line of development, and it needs to be updated before it can be merged into the project.
+- `status: in progress 🏗`: this PR is currently being worked on
+- `status: in review 👀`: this PR is currently being reviewed by the team
+- `status: declined 🙅🏻‍♀️`: this PR has been reviewed and declined for merged
+- `status: approved 💪🏾`: this PR has been reviewed and approved for merge
+- `status: blocked ⛔️`: this PR is blocked by another PR or issue
+
+GitHub notifies team member when labels are changed, so it is useful to keep the status of each pull request as close as possible with the reality.
+For example, if you realize that your PR needs more work after a first pass review, then change the label to `status: in progress 🏗`.
+
+**All PR's must be tagged with a status at all times**
 
 ## Issue and PR templates
 


### PR DESCRIPTION
This PR adds:

- Adds rationale for PR labels 
- Replaces labels in the docs with plain text md (reduce contrast issues and makes it easier to maintain)


## Reference Issues or PRs

Complements #218 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->

I did not notice until now I also updated the pre-commits 🤦🏽‍♀️  If you'd prefer me to split this PR into two I can do