### PR TITLE
Fix typo causing bad rendering (extra backtick)

### DIFF
--- a/docs/docs/explanations/advanced-configuration.md
+++ b/docs/docs/explanations/advanced-configuration.md
@@ -265,7 +265,7 @@ domain: demo.nebari.dev
 
 `project_name`: Determines the base name for all major infrastructure related resources on Nebari. Should be compatible with the Cloud provider's naming conventions. See [Project Naming Conventions](/docs/explanations/configuration-best-practices.mdx#naming-conventions) for more details.
 
-`namespace``: Used in combination with `project_name` to label infrastructure related resources on Nebari and also determines the target [_namespace_](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) used when deploying kubernetes resources. Defaults to `dev`.
+`namespace`: Used in combination with `project_name` to label infrastructure related resources on Nebari and also determines the target [_namespace_](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) used when deploying kubernetes resources. Defaults to `dev`.
 
 `provider`: Determines the cloud provider used to deploy infrastructure related resources on Nebari. Possible values are:
 


### PR DESCRIPTION
Before:

![image](https://github.com/nebari-dev/nebari-docs/assets/5832902/aa9b2745-163e-498d-8403-830bc9c4e2d1)

After:

![image](https://github.com/nebari-dev/nebari-docs/assets/5832902/3d54c3cc-b701-4da0-b0fe-e4321a6e1a96)
