### PR TITLE
Fix missing `:`

### DIFF
--- a/docs/docs/how-tos/configure-keycloak-howto.md
+++ b/docs/docs/how-tos/configure-keycloak-howto.md
@@ -142,7 +142,7 @@ Users in a particular group will also get access to that groups shared folder. S
 
 Roles on the other hand represent the type or category of user. This includes access and permissions that this category of user will need to perform their regular job duties. The differences between `groups` and `roles` are subtle. Particular roles (one or many), like `conda_store_admin`, are associated with a particular group, such as `admin` and any user in this group will then assume the role of `conda_store_admin`.
 
-::info
+:::info
 These roles can be stacked. This means that if a user is in one group with role `conda_store_admin` and another group with role `conda_store_viewer`, this user ultimately has the role `conda_store_admin`.
 :::
 


### PR DESCRIPTION
Before: 

![image](https://github.com/nebari-dev/nebari-docs/assets/5832902/279e5629-5d58-4eef-9b9b-9b0c4a721878)

After:

![image](https://github.com/nebari-dev/nebari-docs/assets/5832902/12c75abd-d1f7-439e-a32c-d4e3871d26ce)

