### PR TITLE
Use non-permalink for HIGHEST_SUPPORTED_K8S_VERSION

### DIFF
--- a/docs/docs/how-tos/upgrade-kubernetes-version.md
+++ b/docs/docs/how-tos/upgrade-kubernetes-version.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Nebari runs on Kubernetes under the hood, and as administrators of this Kubernetes cluster, one of the maintenance tasks required from time to time is upgrading the version of your Kubernetes cluster. Each of the different cloud providers that Nebari can run on, has their own release cycle and support windows for their flavor of Kubernetes. That said, they tend to follow the [official Kubernetes release cycle](https://kubernetes.io/releases/).
 
-The Nebari development team tries to stay ahead of this by supporting the latest version when possible. However, given that many Kubernetes releases come with a set of deprecations that potentially affect Nebari and downstream plugins, there is an enforced [`HIGHEST_SUPPORTED_K8S_VERSION`](https://github.com/nebari-dev/nebari/blob/develop/src/_nebari/constants.py#L11) allowed.
+The Nebari development team tries to stay ahead of this by supporting the latest version when possible. However, given that many Kubernetes releases come with a set of deprecations that potentially affect Nebari and downstream plugins, there is an enforced [`HIGHEST_SUPPORTED_K8S_VERSION`](https://github.com/nebari-dev/nebari/blob/main/src/_nebari/constants.py#L11) allowed.
 
 
 :::note

--- a/docs/docs/how-tos/upgrade-kubernetes-version.md
+++ b/docs/docs/how-tos/upgrade-kubernetes-version.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Nebari runs on Kubernetes under the hood, and as administrators of this Kubernetes cluster, one of the maintenance tasks required from time to time is upgrading the version of your Kubernetes cluster. Each of the different cloud providers that Nebari can run on, has their own release cycle and support windows for their flavor of Kubernetes. That said, they tend to follow the [official Kubernetes release cycle](https://kubernetes.io/releases/).
 
-The Nebari development team tries to stay ahead of this by supporting the latest version when possible. However, given that many Kubernetes releases come with a set of deprecations that potentially affect Nebari and downstream plugins, there is an enforced [`HIGHEST_SUPPORTED_K8S_VERSION`](https://github.com/nebari-dev/nebari/blob/91792952b67074b5c15c3b4009bde5926ca4ec6b/src/_nebari/constants.py#L11) allowed.
+The Nebari development team tries to stay ahead of this by supporting the latest version when possible. However, given that many Kubernetes releases come with a set of deprecations that potentially affect Nebari and downstream plugins, there is an enforced [`HIGHEST_SUPPORTED_K8S_VERSION`](https://github.com/nebari-dev/nebari/blob/develop/src/_nebari/constants.py#L11) allowed.
 
 
 :::note


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Relates to https://github.com/nebari-dev/nebari/issues/2301, https://github.com/nebari-dev/nebari/pull/2276
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

The permalink to an old commit led me down a bit of a rabbit hole through the issues/PRs above to find out Nebari's plans for 1.26's planned EOL (e.g., references above). I think it would make more sense to use a non-permalink so readers are taken to the lastest commit and can see the current maximum supported k8s version. That said, I'm not sure whether the branch should be `develop` or `main` (this PR currently uses the default branch of `develop`).

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [X] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [X] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [X] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [X] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [X] This content adheres to the Nebari style guides.

#### Non-text content

- [X] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [X] If there are emojis, there are not more than three in a row.
- [X] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [X] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
