### PR TITLE
Fix yarn lint/format

### DIFF
--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Lint 🔍
         run: yarn run lint
 
+      - name: Format 🥇
+        run: yarn run format
+
       - name: Build site 🔨
         run: yarn run build

--- a/docs/docs/explanations/advanced-custom-settings.md
+++ b/docs/docs/explanations/advanced-custom-settings.md
@@ -277,6 +277,7 @@ Select the virtual network and subnet name under the networking settings of your
 and then follow the usual deployment instructions as you would deploy from your local machine.
 
 =======
+
 #### Conda store worker
 
 You can use the following settings to change the defaults settings (shown) used for Conda store workers.

--- a/docs/docs/how-tos/access-logs-loki.md
+++ b/docs/docs/how-tos/access-logs-loki.md
@@ -14,7 +14,7 @@ To view the Loki logs via Grafana in Nebari, you'll need to have [set up monitor
 Access the Monitoring UI for your Nebari installation at https://{your-nebari-domain}/monitoring/.
 
 :::note
-The **Explore** functionality shown below is only available to users who have `grafana_admin` permissions.  In Nebari's default configuration, only the users in the `admin` Keycloak user group will have this role.  `grafana_admin` is a client role in Keycloak which can be assigned to other groups or users.  See [Configure Keycloak](/docs/how-tos/configuring-keycloak#in-depth-look-at-roles-and-groups) for more information.
+The **Explore** functionality shown below is only available to users who have `grafana_admin` permissions. In Nebari's default configuration, only the users in the `admin` Keycloak user group will have this role. `grafana_admin` is a client role in Keycloak which can be assigned to other groups or users. See [Configure Keycloak](/docs/how-tos/configuring-keycloak#in-depth-look-at-roles-and-groups) for more information.
 :::
 
 First, click "Explore".

--- a/docs/docs/how-tos/jhub-app-launcher.md
+++ b/docs/docs/how-tos/jhub-app-launcher.md
@@ -8,8 +8,8 @@ description: Using JHub App Launcher with Nebari
 
 [JHub App Launcher](https://jhub-apps.nebari.dev/) is a generalized server launcher
 for deploying web applications via JupyterHub. The App Launcher serves as the "home"
-page for Nebari - providing access to various Nebari services (e.g. JupyterLab, VS Code, 
-conda-store) and access to deploy custom web apps. 
+page for Nebari - providing access to various Nebari services (e.g. JupyterLab, VS Code,
+conda-store) and access to deploy custom web apps.
 
 ![JHub App Launcher home screen](/img/how-tos/jhub_apps_home.png)
 
@@ -42,11 +42,11 @@ and is not enabled by default.
 
 ## Usage
 
-Documentation on how to create apps is included in the 
+Documentation on how to create apps is included in the
 [JHub Apps documentation](https://jhub-apps.nebari.dev/docs/category/create-apps).
-Deployed apps on Nebari will utilize environments from conda-store. All apps 
-will need to include `jhsingle-native-proxy >= 0.8.2` in their environment along with 
-other framework-specific dependencies. For example, deploying a `panel` app will 
-require `panel` itself and additional tools for deploying `panel` apps such as 
-`bokeh-root-cmd >= 0.1.2`. See the documentation for specific requirements on 
-each framework. 
+Deployed apps on Nebari will utilize environments from conda-store. All apps
+will need to include `jhsingle-native-proxy >= 0.8.2` in their environment along with
+other framework-specific dependencies. For example, deploying a `panel` app will
+require `panel` itself and additional tools for deploying `panel` apps such as
+`bokeh-root-cmd >= 0.1.2`. See the documentation for specific requirements on
+each framework.

--- a/docs/docs/how-tos/nebari-environment-management.md
+++ b/docs/docs/how-tos/nebari-environment-management.md
@@ -12,7 +12,7 @@ Nebari configuration and deployment is highly dependent on the version of the Ne
 
 Once installed, you can use [manage environments](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#managing-environments) in different ways.
 
-This is a simple way to set up a new Conda environment named `nebari0` with a specific Nebari version and exactly one extension installed. This `nebari0` environment will store all of our packages, including those installed with `pip` because when **pip** is installed into an active conda environment, packages which are then installed with pip will not be saved in the global namespace\_. This especially critical when working with extensions, because `nebari` will detect and apply any extensions installed in your Python environment when it runs.
+This is a simple way to set up a new Conda environment named `nebari0` with a specific Nebari version and exactly one extension installed. This `nebari0` environment will store all of our packages, including those installed with `pip` because when **pip** is installed into an active conda environment, packages which are then installed with pip will not be saved in the global namespace. This especially critical when working with extensions, because `nebari` will detect and apply any extensions installed in your Python environment when it runs.
 
 ```
 conda create -n nebari0

--- a/docs/docs/how-tos/nebari-environment-management.md
+++ b/docs/docs/how-tos/nebari-environment-management.md
@@ -6,13 +6,13 @@ description: Best Practices for Managing Your Python Environment
 
 # Nebari Deployment Python Environment Setup
 
-To configure and deploy the Nebari platform, you'll first need to set up your python environment. 
+To configure and deploy the Nebari platform, you'll first need to set up your python environment.
 
 Nebari configuration and deployment is highly dependent on the version of the Nebari CLI that you have active when you run `nebari` commands. A such, we highly recommend [installing Conda](https://docs.anaconda.com/free/anaconda/install/) for managing isolated Python environments, especially when working on more than one Nebari deployment from the same machine or using [Nebari extensions][nebari-extension-system].
 
 Once installed, you can use [manage environments](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#managing-environments) in different ways.
 
-This is a simple way to set up a new Conda environment named `nebari0` with a specific Nebari version and exactly one extension installed. This `nebari0` environment will store all of our packages, including those installed with `pip` because when **pip** is installed into an active conda environment, packages which are then installed with pip will not be saved in the global namespace_. This especially critical when working with extensions, because `nebari` will detect and apply any extensions installed in your Python environment when it runs.
+This is a simple way to set up a new Conda environment named `nebari0` with a specific Nebari version and exactly one extension installed. This `nebari0` environment will store all of our packages, including those installed with `pip` because when **pip** is installed into an active conda environment, packages which are then installed with pip will not be saved in the global namespace\_. This especially critical when working with extensions, because `nebari` will detect and apply any extensions installed in your Python environment when it runs.
 
 ```
 conda create -n nebari0

--- a/docs/docs/references/RELEASE.md
+++ b/docs/docs/references/RELEASE.md
@@ -14,33 +14,33 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 > NOTE: Support for Digital Ocean deployments using CLI commands and related Terraform modules is being deprecated. Although Digital Ocean will no longer be directly supported in future releases, you can still deploy to Digital Ocean infrastructure using the current `existing` deployment option.
 
 ## What's Changed
-* Enable authentication by default in jupyter-server by @krassowski in https://github.com/nebari-dev/nebari/pull/2288
-* remove dns sleep by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2550
-* Conda-store permissions v2 + load roles from keycloak by @aktech in https://github.com/nebari-dev/nebari/pull/2531
-* Restrict public access and add bucket encryption using cmk by @dcmcand in https://github.com/nebari-dev/nebari/pull/2525
-* Add overwrite to AWS coredns addon by @dcmcand in https://github.com/nebari-dev/nebari/pull/2538
-* Add a default roles at initialisation by @aktech in https://github.com/nebari-dev/nebari/pull/2546
-* Hide gallery section if no exhibits are configured by @krassowski in https://github.com/nebari-dev/nebari/pull/2549
-* Add note about ~/.bash_profile by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2575
-* Expose jupyterlab-gallery branch and depth options by @krassowski in https://github.com/nebari-dev/nebari/pull/2556
-* #2566 Upgrade Jupyterhub ssh image by @arjxn-py in https://github.com/nebari-dev/nebari/pull/2576
-* Stop copying unnecessary files into user home directory by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2578
-* Include deprecation notes for init/deploy subcommands by @viniciusdc in https://github.com/nebari-dev/nebari/pull/2582
-* Only download jar if file doesn't exist by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2588
-* Remove unnecessary experimental flag by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2606
-* Add typos spell checker to pre-commit by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2568
-* Enh 2451 skip conditionals by @BrianCashProf in https://github.com/nebari-dev/nebari/pull/2569
-* Improve codespell support: adjust and concentrate config to pyproject.toml and fix more typos by @yarikoptic in https://github.com/nebari-dev/nebari/pull/2583
-* Move codespell config to pyproject.toml only by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2611
-* Add `depends_on` for bucket encryption by @viniciusdc in https://github.com/nebari-dev/nebari/pull/2615
+
+- Enable authentication by default in jupyter-server by @krassowski in https://github.com/nebari-dev/nebari/pull/2288
+- remove dns sleep by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2550
+- Conda-store permissions v2 + load roles from keycloak by @aktech in https://github.com/nebari-dev/nebari/pull/2531
+- Restrict public access and add bucket encryption using cmk by @dcmcand in https://github.com/nebari-dev/nebari/pull/2525
+- Add overwrite to AWS coredns addon by @dcmcand in https://github.com/nebari-dev/nebari/pull/2538
+- Add a default roles at initialisation by @aktech in https://github.com/nebari-dev/nebari/pull/2546
+- Hide gallery section if no exhibits are configured by @krassowski in https://github.com/nebari-dev/nebari/pull/2549
+- Add note about ~/.bash_profile by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2575
+- Expose jupyterlab-gallery branch and depth options by @krassowski in https://github.com/nebari-dev/nebari/pull/2556
+- #2566 Upgrade Jupyterhub ssh image by @arjxn-py in https://github.com/nebari-dev/nebari/pull/2576
+- Stop copying unnecessary files into user home directory by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2578
+- Include deprecation notes for init/deploy subcommands by @viniciusdc in https://github.com/nebari-dev/nebari/pull/2582
+- Only download jar if file doesn't exist by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2588
+- Remove unnecessary experimental flag by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2606
+- Add typos spell checker to pre-commit by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2568
+- Enh 2451 skip conditionals by @BrianCashProf in https://github.com/nebari-dev/nebari/pull/2569
+- Improve codespell support: adjust and concentrate config to pyproject.toml and fix more typos by @yarikoptic in https://github.com/nebari-dev/nebari/pull/2583
+- Move codespell config to pyproject.toml only by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2611
+- Add `depends_on` for bucket encryption by @viniciusdc in https://github.com/nebari-dev/nebari/pull/2615
 
 ## New Contributors
-* @BrianCashProf made their first contribution in https://github.com/nebari-dev/nebari/pull/2569
-* @yarikoptic made their first contribution in https://github.com/nebari-dev/nebari/pull/2583
 
+- @BrianCashProf made their first contribution in https://github.com/nebari-dev/nebari/pull/2569
+- @yarikoptic made their first contribution in https://github.com/nebari-dev/nebari/pull/2583
 
 **Full Changelog**: https://github.com/nebari-dev/nebari/compare/2024.6.1...2024.7.1
-
 
 ### Release 2024.6.1 - June 26, 2024
 

--- a/docs/docs/references/personas.md
+++ b/docs/docs/references/personas.md
@@ -20,7 +20,6 @@ Each persona is placed in a Nebari user group:
 
 **Admin** represents the people who are in charge of deploying Nebari. They are responsible for maintaining and running the day to day maintenance. This may include cloud account management, conda-store maintenance, kubernetes cluster management and adding/removing end users from the deployment. Our admin is [Taylor](#taylor)
 
-
 ## Personas
 
 ---

--- a/docs/docs/tutorials/create-dashboard.md
+++ b/docs/docs/tutorials/create-dashboard.md
@@ -132,13 +132,12 @@ Feel free to add more plots or different styles to your plots!
 
 1. On the Nebari Home Page (from JupyterLab, click on the Nebari logo in the top right corner or go to `File` -> `Home`) click on **"Create App"** to create a new web application for your dashboard.
 2. Follow the [general instructions](https://jhub-apps.nebari.dev/docs/create-apps/general-app) from the JHub Apps documentation to fill out the `Create app` form.
-3. Click **Next**. You'll be redirected to the Spawner profile page. This page will allow you to select the server in which you want your app to run. These options will vary based on the setup of your Nebari deployment (which server types are available overall) and the permissions of your user (which server types you personally have access to). 
+3. Click **Next**. You'll be redirected to the Spawner profile page. This page will allow you to select the server in which you want your app to run. These options will vary based on the setup of your Nebari deployment (which server types are available overall) and the permissions of your user (which server types you personally have access to).
 4. JHub App Launcher will deploy your app (which can take several minutes to complete) and automatically redirect you to it.
 
 Your dashboard app will be available in the Nebari Home page, under "My Apps". If you allowed shared access, it will be available under "Shared Apps" for those with whom you have shared the app.
 
 </TabItem>
-
 
 <TabItem value="cds-dashboards" label="CDS Dashboard" default>
 


### PR DESCRIPTION
The yarn linter and formatter is only run on commit if devs have run `yarn install` which sets up the pre-commit hooks via husky. 

The script `yarn run lint-staged` is what _should_ run on commit. It then calls `yarn run lint` and `yarn run format`. 

However, you can build docs without formally running `yarn install` which has led to the files in the repo getting merged without formatting. This is possible since we check `yarn run lint` in CI, but we don't have `yarn run format`. This PR adds `yarn run format` to CI to catch it in CI and also fixes all the files which slipped through the cracks (even though I just did this [less than a week ago](https://github.com/nebari-dev/nebari-docs/pull/489))

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
