### PR TITLE
Ensure link to jhub app installation docs exists for users following the jhub tutorial

### DIFF
--- a/docs/docs/tutorials/create-dashboard.md
+++ b/docs/docs/tutorials/create-dashboard.md
@@ -29,6 +29,8 @@ import TabItem from '@theme/TabItem';
 
 JHub App launcher supports `Panel`, `Bokeh`, `Streamlit`, `Plotly Dash`, `Voila`, `Gradio`, `JupyterLab`, and `Any generic Python command`.
 
+In order to use JHub App to create apps, ensure it is enabled in your Nebari deployment. See the [JHub App Launcher docs][jub-app-launcher] for instructions on enabling and using JHub App in Nebari.
+
 </TabItem>
 <TabItem value="cds-dashboards" label="CDS Dashboards">
 
@@ -232,3 +234,4 @@ Dashboards and apps can be very handy tools to share information and insights wi
 
 [login-keycloak]: /docs/tutorials/login-keycloak
 [create-env]: /docs/tutorials/creating-new-environments
+[jub-app-launcher]: /docs/how-tos/jhub-app-launcher


### PR DESCRIPTION

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

