### PR TITLE
Add code conventions page to community docs

### DIFF
--- a/docs/community/code-contributions.mdx
+++ b/docs/community/code-contributions.mdx
@@ -183,6 +183,12 @@ If you need help with a test case, you can create a draft pull request and messa
 
 [For tips and best practices, read Test your Nebari contribution ->][community-tests]
 
+### Code conventions
+
+Pydantic model fields that default to `None` must include `None` in their type annotation (for example, `Optional[str]`, `str | None`, or `Union[str, None]`).
+Without the explicit `None` type, Pydantic may silently coerce the value and static type checkers cannot detect the mismatch.
+This rule is enforced by `tests/tests_unit/test_code_conventions.py` in the main repository.
+
 ### Document changes
 
 Prioritize including relevant documentation with your contributions to help your code reviewers, Nebari users, as well as other contributors who may interact with your code.


### PR DESCRIPTION
## Reference Issues or PRs

See also: nebari-dev/nebari#3209 (companion PR adding the enforcement test)

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

Adds a brief "Code conventions" subsection to the existing code
contributions page documenting the Pydantic Optional field rule.

### Access-centered content checklist

#### Text styling

- [x] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [x] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [x] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [x] This content adheres to the Nebari style guides.

#### Non-text content

- [x] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [x] If there are emojis, there are not more than three in a row.
- [x] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [x] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

Documentation companion to the enforcement PR in the main nebari repo.