### PR TITLE
Switch analytics to GA4 with GDPR cookie consent banner

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -67,6 +67,10 @@ const config = {
       "classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
+        gtag: {
+          trackingID: 'G-NXNMX83GGS',
+          anonymizeIP: true,
+        },
         docs: {
           path: "docs",
           routeBasePath: "docs",

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -109,8 +109,31 @@ const config = {
         routeBasePath: 'community',
         sidebarPath: './sidebarsCommunity.js',
       },
-    ]
+    ],
   ],
+
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML:
+        "window.dataLayer = window.dataLayer || [];" +
+        "function gtag(){dataLayer.push(arguments);}" +
+        "gtag('consent', 'default', {" +
+        "  ad_storage: 'denied'," +
+        "  ad_user_data: 'denied'," +
+        "  ad_personalization: 'denied'," +
+        "  analytics_storage: 'denied'," +
+        "  functionality_storage: 'denied'," +
+        "  personalization_storage: 'denied'," +
+        "  security_storage: 'granted'," +
+        "  wait_for_update: 500" +
+        "});" +
+        "gtag('set', 'ads_data_redaction', true);",
+    },
+  ],
+
+  clientModules: [require.resolve('./src/cookieConsent.js')],
   customFields: { ...customFields },
 
   // ---------------------------------------------------------------------------

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -52,15 +52,6 @@ const config = {
     locales: ["en"],
   },
   // ---------------------------------------------------------------------------
-  // Add plausible as script
-  scripts: [
-    {
-      src: "https://plausible.io/js/script.js",
-      defer: true,
-      "data-domain": customFields.domain,
-    },
-  ],
-  // ---------------------------------------------------------------------------
   // Edit presets
   presets: [
     [

--- a/docs/package.json
+++ b/docs/package.json
@@ -53,7 +53,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
-    "sass": "^1.77.8"
+    "sass": "^1.77.8",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.1",

--- a/docs/src/cookieConsent.js
+++ b/docs/src/cookieConsent.js
@@ -1,0 +1,66 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+  (async () => {
+    const CookieConsent = await import('vanilla-cookieconsent');
+    await import('vanilla-cookieconsent/dist/cookieconsent.css');
+
+    const updateGtag = (analyticsGranted) => {
+      window.dataLayer = window.dataLayer || [];
+      const gtag = (...args) => window.dataLayer.push(args);
+      gtag('consent', 'update', {
+        analytics_storage: analyticsGranted ? 'granted' : 'denied',
+      });
+    };
+
+    CookieConsent.run({
+      guiOptions: {
+        consentModal: { layout: 'box', position: 'bottom right' },
+        preferencesModal: { layout: 'box' },
+      },
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: {},
+      },
+      language: {
+        default: 'en',
+        translations: {
+          en: {
+            consentModal: {
+              title: 'Cookie Consent',
+              description:
+                'We use cookies to analyze site traffic and improve your experience. See our <a href="/docs/privacy">Privacy Policy</a>.',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              showPreferencesBtn: 'Manage preferences',
+            },
+            preferencesModal: {
+              title: 'Cookie preferences',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              savePreferencesBtn: 'Save preferences',
+              closeIconLabel: 'Close',
+              sections: [
+                {
+                  title: 'Strictly necessary',
+                  description:
+                    'These cookies are essential for the site to function and cannot be disabled.',
+                  linkedCategory: 'necessary',
+                },
+                {
+                  title: 'Analytics',
+                  description:
+                    'Help us understand how visitors use the site so we can improve it.',
+                  linkedCategory: 'analytics',
+                },
+              ],
+            },
+          },
+        },
+      },
+      onFirstConsent: () => updateGtag(CookieConsent.acceptedCategory('analytics')),
+      onChange: () => updateGtag(CookieConsent.acceptedCategory('analytics')),
+      onConsent: () => updateGtag(CookieConsent.acceptedCategory('analytics')),
+    });
+  })();
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -11328,6 +11328,11 @@ value-equal@^1.0.1:
   resolved "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
+vanilla-cookieconsent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz#0f430f4788e9a09e22e795088889b0679a88a263"
+  integrity sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"


### PR DESCRIPTION
## Description

Switches nebari.dev analytics from Plausible to Google Analytics (GA4).

Also adds a cookie consent banner that blocks GA4 until the user provides consent. Since GA4 uses tracking cookies, GDPR requires opt-in before those cookies can be set.

## What does this implement/fix?

- [x] New feature (non-breaking change which adds a feature)

### What's included

- **Plausible removed** — the existing `plausible.io/js/script.js` `scripts` entry is dropped from the Docusaurus config.
- **GA4** wired through Docusaurus's built-in `gtag` preset option (tracking ID `G-NXNMX83GGS`, IP anonymization on).
- **Cookie consent banner** via [`vanilla-cookieconsent`](https://github.com/orestbida/cookieconsent), a framework-agnostic library with no React peer-dep constraints, wired in through a small Docusaurus client module.
- **Google Consent Mode v2** defaults injected via `headTags` before `gtag.js` loads, so no tracking fires on first paint.

### Expected behavior

- On first visit, a consent banner appears in the bottom-right corner and no GA4 cookies are set.
- Two categories are exposed: **Strictly necessary** (always on) and **Analytics** (opt-in, controls GA4).
- Clicking **Accept all** enables GA4 tracking and remembers the choice.
- Clicking **Reject all** keeps tracking disabled; the banner does not reappear.
- Users can reopen **Manage preferences** later to change their choice, and GA4 updates immediately.
