### PR TITLE
Add GDPR cookie consent banner for Google Analytics

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -105,7 +105,21 @@ const config = {
         routeBasePath: 'community',
         sidebarPath: './sidebarsCommunity.js',
       },
-    ]
+    ],
+    [
+      'docusaurus-plugin-cookie-consent',
+      {
+        title: 'Cookie Consent',
+        description: 'We use cookies to analyze site traffic and improve your experience.',
+        links: [{ label: 'Privacy Policy', href: '/docs/privacy' }],
+        googleConsentMode: {
+          enabled: true,
+          waitForUpdate: 500,
+          adsDataRedaction: true,
+          urlPassthrough: false,
+        },
+      },
+    ],
   ],
   customFields: { ...customFields },
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -106,21 +106,9 @@ const config = {
         sidebarPath: './sidebarsCommunity.js',
       },
     ],
-    [
-      'docusaurus-plugin-cookie-consent',
-      {
-        title: 'Cookie Consent',
-        description: 'We use cookies to analyze site traffic and improve your experience.',
-        links: [{ label: 'Privacy Policy', href: '/docs/privacy' }],
-        googleConsentMode: {
-          enabled: true,
-          waitForUpdate: 500,
-          adsDataRedaction: true,
-          urlPassthrough: false,
-        },
-      },
-    ],
   ],
+
+  clientModules: [require.resolve('./src/cookieConsent.js')],
   customFields: { ...customFields },
 
   // ---------------------------------------------------------------------------

--- a/docs/package.json
+++ b/docs/package.json
@@ -47,14 +47,14 @@
     "clsx": "^2.1.1",
     "dedent": "^0.7.0",
     "docusaurus-lunr-search": "^3.3.0",
-    "docusaurus-plugin-cookie-consent": "^1.0.0",
     "docusaurus-plugin-sass": "^0.2.5",
     "prism-react-renderer": "^2.1.0",
     "raw-loader": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
-    "sass": "^1.77.8"
+    "sass": "^1.77.8",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -47,6 +47,7 @@
     "clsx": "^2.1.1",
     "dedent": "^0.7.0",
     "docusaurus-lunr-search": "^3.3.0",
+    "docusaurus-plugin-cookie-consent": "^1.0.0",
     "docusaurus-plugin-sass": "^0.2.5",
     "prism-react-renderer": "^2.1.0",
     "raw-loader": "^4.0.2",

--- a/docs/src/cookieConsent.js
+++ b/docs/src/cookieConsent.js
@@ -1,0 +1,55 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+  (async () => {
+    const CookieConsent = await import('vanilla-cookieconsent');
+    await import('vanilla-cookieconsent/dist/cookieconsent.css');
+
+    CookieConsent.run({
+      guiOptions: {
+        consentModal: { layout: 'box', position: 'bottom right' },
+        preferencesModal: { layout: 'box' },
+      },
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: {},
+      },
+      language: {
+        default: 'en',
+        translations: {
+          en: {
+            consentModal: {
+              title: 'Cookie Consent',
+              description:
+                'We use cookies to analyze site traffic and improve your experience. See our <a href="/docs/privacy">Privacy Policy</a>.',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              showPreferencesBtn: 'Manage preferences',
+            },
+            preferencesModal: {
+              title: 'Cookie preferences',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              savePreferencesBtn: 'Save preferences',
+              closeIconLabel: 'Close',
+              sections: [
+                {
+                  title: 'Strictly necessary',
+                  description:
+                    'These cookies are essential for the site to function and cannot be disabled.',
+                  linkedCategory: 'necessary',
+                },
+                {
+                  title: 'Analytics',
+                  description:
+                    'Help us understand how visitors use the site so we can improve it.',
+                  linkedCategory: 'analytics',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+  })();
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -11328,6 +11328,11 @@ value-equal@^1.0.1:
   resolved "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
+vanilla-cookieconsent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz#0f430f4788e9a09e22e795088889b0679a88a263"
+  integrity sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"


### PR DESCRIPTION
## Reason

GA4 sets cookies that track visitors. EU privacy law (GDPR) requires opt-in consent before any tracking cookies are placed. This adds a cookie consent banner that blocks Google Analytics until the user accepts.

## What does this implement/fix?

- [x] New feature (non-breaking change which adds a feature)

Uses [`vanilla-cookieconsent`](https://github.com/orestbida/cookieconsent), a framework-agnostic library with no React peer-dep constraints. Wired in via a small Docusaurus client module so it only runs in the browser.

### Expected behavior

- On first visit, a consent banner appears in the bottom-right corner.
- Two categories are exposed: **Strictly necessary** (always on) and **Analytics** (opt-in).
- Clicking **Accept all**, **Reject all**, or saving via **Manage preferences** stores the choice so the banner does not reappear.
- Users can reopen **Manage preferences** later to change their choice.
