### PR TITLE
Fix homepage links in dark mode

### DIFF
--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -47,7 +47,7 @@ export default function HomePage() {
               <li className={styles.pitchItem}>
                 <LeavesCircleSvg aria-hidden="true" height="150px" />
                 <span className={styles.pitchItemHeading}>
-                  <a href="https://github.com/nebari-dev/nebari">Nebari classic</a>
+                  <a href="https://github.com/nebari-dev/nebari" className={styles.pitchItemHeadingLink}>Nebari classic</a>
                 </span>
                 <p>
                   Cloud-agnostic data science platform with environment management, role-based-access control,
@@ -57,7 +57,7 @@ export default function HomePage() {
               <li className={styles.pitchItem}>
                 <JarPlantSvg aria-hidden="true" height="150px" />
                 <span className={styles.pitchItemHeading}>
-                  <a href="https://github.com/nebari-dev/nebari-infrastructure-core">Nebari core (early access)</a>
+                  <a href="https://github.com/nebari-dev/nebari-infrastructure-core" className={styles.pitchItemHeadingLink}>Nebari core (early access)</a>
                 </span>
                 <p>
                   New robust core infrastructure layer for platform deployment on popular cloud providers.
@@ -67,7 +67,7 @@ export default function HomePage() {
               <li className={styles.pitchItem}>
                 <JarPlantSvg aria-hidden="true" height="150px" />
                 <span className={styles.pitchItemHeading}>
-                  <a href="https://github.com/nebari-dev/nebi">Nebi (early access)</a>
+                  <a href="https://github.com/nebari-dev/nebi" className={styles.pitchItemHeadingLink}>Nebi (early access)</a>
                 </span>
                 <p>
                   Tools to manage, share, and collaborate on AI software lifecycle across your team.

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -130,6 +130,18 @@ because it mixes dark and light sections.
   font-weight: 600;
 }
 
+.pitchItemHeadingLink,
+[data-theme=light] .pitchItemHeadingLink,
+[data-theme=dark] .pitchItemHeadingLink {
+  color: var(--ifm-color-black);
+}
+
+.pitchItemHeadingLink:hover,
+[data-theme=light] .pitchItemHeadingLink:hover,
+[data-theme=dark] .pitchItemHeadingLink:hover {
+  color: var(--ifm-link-color);
+}
+
 /*
   Deploy anywhere
 */


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #640 

Add a css class to heading elements that are links, to override default behavior. 

The homepage only has a "light mode" variant (even when the rest of the docs are in dark mode). Hence, we can't change any dark mode defaults here.

## What does this implement/fix?

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Did you test the pull request locally?
