### PR TITLE
Update Nebari tagline in metadata

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,7 +18,7 @@ const customFields = {
   copyright: `Copyright © ${new Date().getFullYear()} | Made with 💜   by the Nebari dev team `,
   meta: {
     title: "Nebari",
-    description: "Your open source data science platform. Built for scale, designed for collaboration.",
+    description: "An open source stack for your AI.",
     keywords: ["Jupyter", "MLOps", "Kubernetes", "Python", "Dask"],
   },
   domain,

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -16,7 +16,7 @@ export default function HomePage() {
   return (
     <Layout
       title="Nebari Homepage"
-      description="TODO"
+      description="An open source stack for your AI."
     >
       <main className={styles.main}>
         <section className={styles.heroSection}>


### PR DESCRIPTION
#599 updated the landing page, and added a new tagline. This tagline also need to be updated in some metadata elements.

This will also fix the previews on Slack and socials, that currently looks like:

<img width="269" height="112" alt="Screenshot 2026-04-28 at 10 14 51" src="https://github.com/user-attachments/assets/246aa5f2-bb86-4913-b78b-ed8e54b91c04" />

## What does this implement/fix?

- [x] Documentation Update

## Testing

- [x] Did you test the pull request locally?


