### PR TITLE
fix(references): unblock CI on imported RELEASE.md and prevent recurrence

### DIFF
--- a/.github/workflows/auto-format-release.yml
+++ b/.github/workflows/auto-format-release.yml
@@ -42,15 +42,28 @@ jobs:
           import re
           from pathlib import Path
 
+          # HTML tags MDX renders natively; do not wrap these in backticks.
+          HTML_PASSTHROUGH = {
+              "details", "summary", "kbd", "mark", "br", "hr",
+              "code", "pre", "em", "strong", "b", "i", "u",
+              "del", "ins", "abbr", "sup", "sub", "small",
+          }
+
           path = Path("docs/docs/references/RELEASE.md")
           text = path.read_text()
           pattern = re.compile(r"<([a-z][a-zA-Z0-9_-]*)>")
+
+          def replace(match: re.Match) -> str:
+              tag = match.group(1)
+              if tag in HTML_PASSTHROUGH:
+                  return match.group(0)
+              return f"`<{tag}>`"
 
           def fix_line(line: str) -> str:
               # Skip parts already inside inline backticks; escape <token> elsewhere.
               segments = re.split(r"(`[^`]*`)", line)
               return "".join(
-                  seg if seg.startswith("`") else pattern.sub(r"`<\1>`", seg)
+                  seg if seg.startswith("`") else pattern.sub(replace, seg)
                   for seg in segments
               )
 

--- a/.github/workflows/auto-format-release.yml
+++ b/.github/workflows/auto-format-release.yml
@@ -1,5 +1,10 @@
 name: Auto-format imported RELEASE.md
 
+# NOTE: This workflow is expected to be deprecated soon.
+# Scheduled releases of nebari (classic) are no longer happening
+# on a regular schedule, so this auto-format step will rarely
+# run and may be removed once upstream sync activity stops entirely.
+#
 # When the upstream sync bot opens a PR that touches
 # docs/docs/references/RELEASE.md, the file often arrives with two
 # common problems that block CI:

--- a/.github/workflows/auto-format-release.yml
+++ b/.github/workflows/auto-format-release.yml
@@ -1,0 +1,70 @@
+name: Auto-format imported RELEASE.md
+
+# When the upstream sync bot opens a PR that touches
+# docs/docs/references/RELEASE.md, the file often arrives with two
+# common problems that block CI:
+#
+#   1. Prettier formatting (missing blank lines after headings)
+#   2. Bare <foo> tokens in prose that the MDX parser treats as JSX tags
+#
+# This workflow runs on those PRs, applies both fixes, and pushes the
+# result back so the PR's downstream checks (Test Website, Netlify)
+# can pass without manual intervention.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/docs/references/RELEASE.md'
+
+permissions:
+  contents: write
+
+jobs:
+  fix-release:
+    runs-on: ubuntu-latest
+    # Only run on PRs from the same repository (not forks), since we
+    # need to push commits back to the PR branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Escape unescaped <token> patterns
+        run: |
+          python3 <<'EOF'
+          import re
+          from pathlib import Path
+
+          path = Path("docs/docs/references/RELEASE.md")
+          text = path.read_text()
+          pattern = re.compile(r"<([a-z][a-zA-Z0-9_-]*)>")
+
+          def fix_line(line: str) -> str:
+              # Skip parts already inside inline backticks; escape <token> elsewhere.
+              segments = re.split(r"(`[^`]*`)", line)
+              return "".join(
+                  seg if seg.startswith("`") else pattern.sub(r"`<\1>`", seg)
+                  for seg in segments
+              )
+
+          path.write_text("".join(fix_line(line) for line in text.splitlines(keepends=True)))
+          EOF
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run Prettier on RELEASE.md
+        working-directory: ./docs
+        run: |
+          yarn install --frozen-lockfile
+          npx prettier --write docs/references/RELEASE.md
+
+      - name: Commit changes back to the PR
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: auto-format imported RELEASE.md'
+          file_pattern: docs/docs/references/RELEASE.md

--- a/docs/docs/references/RELEASE.md
+++ b/docs/docs/references/RELEASE.md
@@ -1221,7 +1221,7 @@ Explicit user facing changes:
 
 ### What's Changed
 
-<details>
+`<details>`
 
 - Enabling Vale CI with GitHub Actions by @HarshCasper in https://github.com/Quansight/qhub/pull/871
 - Qhub upgrade by @danlester in https://github.com/Quansight/qhub/pull/870

--- a/docs/docs/references/RELEASE.md
+++ b/docs/docs/references/RELEASE.md
@@ -72,7 +72,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 
 ## Release 2025.4.2 - April 25, 2025
 
-> NOTE: You may notice messages like `groups: cannot find name for group ID <number>` when using the terminal. These warnings are harmless and do not affect system functionality or permissions. We're aware of the issue and it will be resolved in the next version.
+> NOTE: You may notice messages like groups: cannot find name for group ID `<number>` when using the terminal. These warnings are harmless and do not affect system functionality or permissions. We're aware of the issue and it will be resolved in the next version.
 
 ### What's Changed
 
@@ -154,8 +154,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 ### New Contributors
 
 - @soapy1 made their first contribution in https://github.com/nebari-dev/nebari/pull2891
-- @smokestacklightnin made their first contribution in https://github.com/nebari-dev
-  /nebari/pull/2839
+- @smokestacklightnin made their first contribution in https://github.com/nebari-dev/nebari/pull/2839
 - @kernel-loophole made their first contribution in https://github.com/nebari-dev/nebari/pull/2916
 
 **Full Changelog**: https://github.com/nebari-dev/nebari/compare/2024.12.1...2025.2.1
@@ -1221,7 +1220,7 @@ Explicit user facing changes:
 
 ### What's Changed
 
-`<details>`
+<details>
 
 - Enabling Vale CI with GitHub Actions by @HarshCasper in https://github.com/Quansight/qhub/pull/871
 - Qhub upgrade by @danlester in https://github.com/Quansight/qhub/pull/870

--- a/docs/docs/references/RELEASE.md
+++ b/docs/docs/references/RELEASE.md
@@ -36,6 +36,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 > If you previously applied `aws eks update-addon --service-account-role-arn …` manually to recover from the EBS CSI controller crashloop on AL2023, your addon is in drift relative to Terraform. Before deploying, either re-run `aws eks update-addon` with the canonical role ARN (`<cluster_name>-ebs-csi-driver`), or detach the manual override with `--remove-service-account-role-arn` and let Terraform reattach the correct role. Skipping this step results in `AccessDeniedException: Cross-account pass role is not allowed` on apply.
 
 ### What's Changed
+
 - Remove notice after 2025.10.1 release by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/3180
 - old package gpg version expired - update to latest by @tylerpotts in https://github.com/nebari-dev/nebari/pull/3178
 - Use latest Kubernetes versions for GCP clusters by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/3182
@@ -59,6 +60,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 ## Release 2025.6.1 - June 06, 2025
 
 ### What's Changed
+
 - Enable resource monitoring for cirun runners by @aktech in https://github.com/nebari-dev/nebari/pull/3047
 - Add filesystem scan in Trivy GHA workflow to scan Python dependencies by @marcelovilla in https://github.com/nebari-dev/nebari/pull/3045
 - Pin click to avoid incompatibility issues with Typer by @marcelovilla in https://github.com/nebari-dev/nebari/pull/3051
@@ -70,9 +72,10 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 
 ## Release 2025.4.2 - April 25, 2025
 
-> NOTE: You may notice messages like groups: cannot find name for group ID <number> when using the terminal. These warnings are harmless and do not affect system functionality or permissions. We're aware of the issue and it will be resolved in the next version.
+> NOTE: You may notice messages like `groups: cannot find name for group ID <number>` when using the terminal. These warnings are harmless and do not affect system functionality or permissions. We're aware of the issue and it will be resolved in the next version.
 
 ### What's Changed
+
 - Upgrade verify-changed-files action by @marcelovilla in https://github.com/nebari-dev/nebari/pull/3037
 - Monkeypatch version validator to avoid failing tests by @marcelovilla in https://github.com/nebari-dev/nebari/pull/3039
 - Upgrade azure-identity by @marcelovilla in https://github.com/nebari-dev/nebari/pull/3038
@@ -82,6 +85,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 ## Release 2025.4.1 - April 11, 2025
 
 ### What's Changed
+
 - [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/nebari-dev/nebari/pull/2969
 - Add extra services checks to kuberhealthy by @viniciusdc in https://github.com/nebari-dev/nebari/pull/2978
 - Add workflow to run conda-store user journey tests by @soapy1 in https://github.com/nebari-dev/nebari/pull/2895
@@ -105,6 +109,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 ## Release 2025.3.1 - March 14, 2025
 
 ### What's Changed
+
 - fix buffer full deadlock by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2929
 - support KubeSpawner profile_options by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2937
 - fix ansi color reset bug by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2970
@@ -126,6 +131,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 > 1.31).
 
 ### What's Changed
+
 - fix bug to allow --import-plugin to work by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2864
 - Add azure kubernetes policy add-on by @viniciusdc in https://github.com/nebari-dev-nebari/pull/2888
 - Yaml config sets by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/287-
@@ -149,7 +155,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 
 - @soapy1 made their first contribution in https://github.com/nebari-dev/nebari/pull2891
 - @smokestacklightnin made their first contribution in https://github.com/nebari-dev
-/nebari/pull/2839
+  /nebari/pull/2839
 - @kernel-loophole made their first contribution in https://github.com/nebari-dev/nebari/pull/2916
 
 **Full Changelog**: https://github.com/nebari-dev/nebari/compare/2024.12.1...2025.2.1
@@ -159,6 +165,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 > NOTE: Support for DigitalOcean has been removed in this release. If you plan to deploy Nebari on DigitalOcean, you first need to independently create a Kubernetes cluster and then use the `existing` deployment option.
 
 ### What's Changed
+
 - Precommit typos by @blakerosenthal in https://github.com/nebari-dev/nebari/pull/2731
 - fix typo in KubernetesCredentials by @blakerosenthal in https://github.com/nebari-dev/nebari/pull/2729
 - handle branch rename from develop to main in github actions by @Adam-D-Lewis in https://github.com/nebari-dev/nebari/pull/2748
@@ -199,6 +206,7 @@ This file is copied to nebari-dev/nebari-docs using a GitHub Action. -->
 - update gcp instance validation by @dcmcand in https://github.com/nebari-dev/nebari/pull/2875
 
 ### New Contributors
+
 - @jcbolling made their first contribution in https://github.com/nebari-dev/nebari/pull/2850
 
 **Full Changelog**: https://github.com/nebari-dev/nebari/compare/2024.11.1...2024.12.1


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #677.

## What does this implement/fix?

- Patches the current `RELEASE.md` so MDX can compile it and Prettier accepts its formatting, unblocking PR CI across the repo.
- Adds a guard workflow (`.github/workflows/auto-format-release.yml`) that triggers on any PR touching `RELEASE.md`, escapes unescaped `<token>` patterns, runs Prettier, and commits the fixes back. This prevents future syncs from the upstream bot from breaking CI in the same way.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Ran the two CI checks locally from `docs/`: `yarn run format` prints "All matched files use Prettier code style", and `npx docusaurus build` ends with `[SUCCESS] Generated static files in "build"`.