### PR TITLE
chore(404): customize NotFound page with NKP and Classic links

### DIFF
--- a/docs/src/theme/NotFound/Content/index.js
+++ b/docs/src/theme/NotFound/Content/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import clsx from 'clsx';
+import Heading from '@theme/Heading';
+
+export default function NotFoundContent({className}) {
+  return (
+    <main className={clsx('container margin-vert--xl', className)}>
+      <div className="row">
+        <div className="col col--6 col--offset-3">
+          <Heading as="h1" className="hero__title">
+            Page not found
+          </Heading>
+          <p>That URL doesn't exist on this site. The docs were recently reorganized; try one of these:</p>
+          <ul>
+            <li><a href="/docs/introduction">Nebari Kubernetes Platform (NKP) overview</a></li>
+            <li><a href="/classic/welcome">Nebari Classic documentation</a></li>
+          </ul>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #683.

## What does this implement/fix?

- Replaces Docusaurus's default 404 ("We could not find what you were looking for") with a short, helpful message that names the recent IA restructure as the likely cause.
- Surfaces two starting points on the 404 page: the Nebari Kubernetes Platform (NKP) overview and the Nebari Classic documentation, so users hitting moved or unknown URLs have an obvious next step.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Verified locally with `yarn build && yarn serve` by navigating to a non-existent URL (`/this-page-does-not-exist`). The custom page renders with the expected H1, intro sentence, and two links pointing at `/docs/introduction` and `/classic/welcome`.