### PR TITLE
docs: add a Prepare to deploy page for one-time setup

### DIFF
--- a/docs/docs/how-tos/deploy.mdx
+++ b/docs/docs/how-tos/deploy.mdx
@@ -5,7 +5,7 @@ description: Common GitOps setup, deploy, verify, update, and destroy steps shar
 ---
 
 :::note
-Start on your provider's page — it walks you through the full deployment and links here for the shared steps. This page covers the lifecycle steps that are common across all NIC-managed providers: setting up a GitOps repository, storing credentials, running `nic deploy`, verifying the cluster, signing in for the first time, updating, and tearing down.
+Start on your provider's page — it walks you through the full deployment and links here for the shared steps. This page covers the lifecycle steps that are common across all NIC-managed providers: running `nic deploy`, verifying the cluster, signing in for the first time, updating, and tearing down.
 :::
 
 Provider-specific prerequisites, configuration, and cost notes are on each [provider's page](/docs/how-tos/providers).
@@ -21,34 +21,9 @@ Regardless of provider, when `nic deploy` finishes your cluster will have:
 
 Each provider adds storage and cluster-type specifics — see the provider pages for details.
 
-## GitOps repository
+## Set up your repository and credentials
 
-NIC uses GitOps: it commits ArgoCD app manifests to a Git repo you own and lets ArgoCD sync them into the cluster.
-
-You'll need:
-
-1. **A Git repo on any host reachable from the cluster** (GitHub, GitLab, Bitbucket, self-hosted Gitea, etc.).
-2. **A GitHub personal access token** (`GIT_TOKEN`) scoped to the GitOps repo with **Contents: read+write**. Go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta), choose **Only select repositories**, pick your GitOps repo, and generate.
-
-   For production, we recommend generating a second token (`ARGOCD_GIT_TOKEN`) with **Contents: read-only**, used by ArgoCD inside the cluster. If you skip it, ArgoCD will reuse `GIT_TOKEN` (which means the cluster has write access to your GitOps repo).
-
-## Secrets and credentials
-
-`nic` reads secrets from a `.env` file in the directory you run `nic` from (loaded via [godotenv](https://github.com/joho/godotenv)). See your provider's page for instructions on downloading the `.env` template.
-
-Ensure `.env` is in your `.gitignore` before you commit anything:
-
-```text
-# .gitignore
-.env
-```
-
-Add your GitOps tokens to `.env`:
-
-```bash
-GIT_TOKEN=github_pat_...             # read+write, used by nic during deploy
-ARGOCD_GIT_TOKEN=github_pat_...      # optional, read-only; used by ArgoCD to pull manifests
-```
+Before deploying, create your GitOps repository and `.env` credentials: see [Prepare to deploy](/docs/how-tos/prepare-to-deploy).
 
 ## Configuration
 

--- a/docs/docs/how-tos/prepare-to-deploy.mdx
+++ b/docs/docs/how-tos/prepare-to-deploy.mdx
@@ -1,0 +1,45 @@
+---
+title: Prepare to deploy
+slug: /how-tos/prepare-to-deploy
+description: "One-time setup before deploying an NKP cluster: create a GitOps repository and store your credentials in a .env file."
+---
+
+This tutorial walks you through the two setup steps required before deploying NKP:
+
+- creating a **GitOps repository** where `nic` can commit app manifests
+- creating a **`.env` file** with your credentials
+
+Provider-specific credentials and configuration are covered on each [provider page](/docs/how-tos/providers).
+
+## GitOps repository
+
+NIC uses GitOps: it commits ArgoCD app manifests to a Git repo you own and lets ArgoCD sync them into the cluster. For how this fits into the platform, see [NKP architecture](/docs/explanations/nkp-architecture).
+
+You'll need:
+
+1. **A Git repo on any host reachable from the cluster** (GitHub, GitLab, Bitbucket, self-hosted Gitea, etc.).
+2. **A GitHub personal access token** (`GIT_TOKEN`) scoped to the GitOps repo with **Contents: read+write**. Go to [github.com/settings/tokens?type=beta](https://github.com/settings/tokens?type=beta), choose **Only select repositories**, pick your GitOps repo, and generate.
+
+:::tip[Recommended for production]
+Generate a second token (`ARGOCD_GIT_TOKEN`) with **Contents: read-only** for ArgoCD to use inside the cluster. If you skip it, ArgoCD reuses `GIT_TOKEN`, which gives the cluster write access to your GitOps repo.
+:::
+
+## Secrets and credentials
+
+`nic` reads secrets from a `.env` file in the directory you run `nic` from (loaded via [godotenv](https://github.com/joho/godotenv)).
+
+Ensure `.env` is in your `.gitignore` before you commit anything:
+
+```text
+# .gitignore
+.env
+```
+
+Add your GitOps tokens to `.env`:
+
+```bash
+GIT_TOKEN=github_pat_...             # read+write, used by nic during deploy
+ARGOCD_GIT_TOKEN=github_pat_...      # optional, read-only; used by ArgoCD to pull manifests
+```
+
+Your [provider's page](/docs/how-tos/providers) lists the provider credentials (cloud keys or profiles) that also belong in this `.env`.

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -39,7 +39,7 @@ Follow the [Install NIC](/docs/get-started/install) guide to download and instal
 
 ### GitOps repository
 
-See [GitOps repository](/docs/how-tos/deploy#gitops-repository) in the deploy lifecycle guide.
+See [GitOps repository](/docs/how-tos/prepare-to-deploy#gitops-repository) in the Prepare to deploy guide.
 
 ### Secrets and credentials
 
@@ -50,7 +50,7 @@ cd /path/to/your-gitops-repo
 curl -o .env https://raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/main/.env.example
 ```
 
-Then uncomment and fill in the AWS block and the GitOps tokens. For `.gitignore` setup and GitOps token configuration, see [Secrets and credentials](/docs/how-tos/deploy#secrets-and-credentials) in the deploy lifecycle guide.
+Then uncomment and fill in the AWS block and the GitOps tokens. For `.gitignore` setup and GitOps token configuration, see [Secrets and credentials](/docs/how-tos/prepare-to-deploy#secrets-and-credentials) in the Prepare to deploy guide.
 
 #### AWS credentials
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -42,6 +42,7 @@ module.exports = {
       label: "How-to guides",
       link: { type: "doc", id: "how-tos/index" },
       items: [
+        "how-tos/prepare-to-deploy",
         "how-tos/deploy",
         {
           type: "category",


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #688.

## What does this implement/fix?

- Adds a dedicated **Prepare to deploy** how-to page covering the one-time setup before deploying NKP: creating a GitOps repository and storing credentials in a `.env` file.
- Slims down the shared **Deploy** page so it focuses on the deployment lifecycle (deploy, verify, sign in, update, destroy) and links out to the new setup page instead of repeating it.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Verified the docs build and the new sidebar entry and cross-page links render correctly.
