### PR TITLE
docs: add a Deploy a cluster page for deploy and verify

### DIFF
--- a/docs/docs/how-tos/deploy-cluster.mdx
+++ b/docs/docs/how-tos/deploy-cluster.mdx
@@ -1,0 +1,68 @@
+---
+title: Deploy a cluster
+slug: /how-tos/deploy-cluster
+description: "Deploy and verify an NKP cluster with nic: validate the config, provision, retrieve the kubeconfig, and confirm the cluster is healthy."
+---
+
+This how-to covers the deploy-and-verify steps shared across all NIC-managed providers: validating your config, provisioning with `nic deploy`, retrieving a kubeconfig, and confirming the cluster is healthy. For how `nic` provisions a cluster, see [NKP architecture](/docs/explanations/nkp-architecture).
+
+:::note
+These steps are the same across all providers. For prerequisites, configuration, and cost notes specific to your environment, see your [provider's page](/docs/how-tos/providers).
+:::
+
+## Configuration
+
+Download a starter config from your provider's page. For the full schema, see the [NIC configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md).
+
+## Deploy
+
+From the directory containing your config file and `.env`:
+
+```bash
+# Quick syntax and shape check; no provider API calls.
+nic validate -f <config-file>
+
+# Validates config and credentials; no resources are created.
+nic deploy -f <config-file> --dry-run
+
+# Actually provision.
+nic deploy -f <config-file>
+```
+
+If you need to extend the default timeout (large clusters, slow network), pass `--timeout 1h`.
+
+## Retrieve the kubeconfig
+
+`nic deploy` does not set your `kubectl` context. Generate a kubeconfig for the new cluster and point `kubectl` at it:
+
+```bash
+# Write the kubeconfig to a file (omit -o to print to stdout).
+nic kubeconfig -f <config-file> -o kubeconfig.yaml
+
+export KUBECONFIG=$(pwd)/kubeconfig.yaml
+```
+
+## Verify
+
+:::note
+The steps below use [`kubectl`](https://kubernetes.io/docs/tasks/tools/). Install it if you don't have it.
+:::
+
+Check that the cluster is responsive:
+
+```bash
+kubectl get nodes
+kubectl get pods -A
+```
+
+Then check the foundational ArgoCD applications are syncing:
+
+```bash
+kubectl get applications -n argocd
+```
+
+All ArgoCD applications should reach `Healthy` within a few minutes (some may briefly show `Progressing` or `OutOfSync` — this is normal).
+
+:::tip
+For an interactive view of all cluster resources (especially handy while watching ArgoCD apps sync), install [k9s](https://k9scli.io/) and run it after setting `KUBECONFIG`.
+:::

--- a/docs/docs/how-tos/deploy.mdx
+++ b/docs/docs/how-tos/deploy.mdx
@@ -5,7 +5,7 @@ description: Common GitOps setup, deploy, verify, update, and destroy steps shar
 ---
 
 :::note
-Start on your provider's page — it walks you through the full deployment and links here for the shared steps. This page covers the lifecycle steps that are common across all NIC-managed providers: setting up a GitOps repository, storing credentials, running `nic deploy`, verifying the cluster, signing in for the first time, updating, and tearing down.
+Start on your provider's page — it walks you through the full deployment and links here for the shared steps. This page covers the lifecycle steps that are common across all NIC-managed providers: setting up a GitOps repository, storing credentials, deploying and verifying the cluster, signing in for the first time, updating, and tearing down.
 :::
 
 Provider-specific prerequisites, configuration, and cost notes are on each [provider's page](/docs/how-tos/providers).
@@ -50,58 +50,16 @@ GIT_TOKEN=github_pat_...             # read+write, used by nic during deploy
 ARGOCD_GIT_TOKEN=github_pat_...      # optional, read-only; used by ArgoCD to pull manifests
 ```
 
-## Configuration
+## Deploy and verify
 
-Download a starter config from your provider's page. For the full schema, see the [NIC configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md).
+Download a starter config, validate it, provision the cluster, retrieve a kubeconfig, and confirm the cluster is healthy: see [Deploy a cluster](/docs/how-tos/deploy-cluster).
 
-## Deploy
-
-From the directory containing your config file and `.env`:
-
-```bash
-# Quick syntax and shape check; no provider API calls.
-nic validate -f <config-file>
-
-# Validates config and credentials; no resources are created.
-nic deploy -f <config-file> --dry-run
-
-# Actually provision.
-nic deploy -f <config-file>
-```
-
-If you need to extend the default timeout (large clusters, slow network), pass `--timeout 1h`.
-
-### DNS
+## DNS
 
 After deploy completes, your cluster needs a DNS record to be reachable:
 
 - **Cloudflare-managed domains:** add `CLOUDFLARE_API_TOKEN` to your `.env` with `Zone:DNS:Edit` permission on your domain's zone. `nic` creates the record automatically.
 - **All other DNS providers:** `nic` prints the load balancer's IP address or hostname at the end of deploy. Create an **A/CNAME record** at your DNS provider pointing your domain to that value. The cluster will not be reachable over HTTPS until the record propagates.
-
-## Verify
-
-:::note
-The steps below use [`kubectl`](https://kubernetes.io/docs/tasks/tools/). Install it if you don't have it.
-:::
-
-After setting `KUBECONFIG` (see your provider's page), check that the cluster is responsive:
-
-```bash
-kubectl get nodes
-kubectl get pods -A
-```
-
-Then check the foundational ArgoCD applications are syncing:
-
-```bash
-kubectl get applications -n argocd
-```
-
-All ArgoCD applications should reach `Healthy` within a few minutes (some may briefly show `Progressing` or `OutOfSync` — this is normal).
-
-:::tip
-For an interactive view of all cluster resources (especially handy while watching ArgoCD apps sync), install [k9s](https://k9scli.io/) and run it after setting `KUBECONFIG`.
-:::
 
 ## First sign-in
 

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -147,11 +147,15 @@ To use `aws-config-with-dns.yaml`, [generate a Cloudflare API token](https://das
 
 For the full schema (brownfield VPC adoption, custom KMS keys, advanced node-group options, Longhorn, log types), see the [NIC configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md).
 
-## Deploy
+## Deploy and verify
 
-Run the deploy commands as described in [Deploy](/docs/how-tos/deploy#deploy) in the deploy lifecycle guide. Allow at least 30 minutes for the first deployment — EKS control-plane creation takes about 10 minutes, followed by ArgoCD syncing foundational services.
+Follow [Deploy a cluster](/docs/how-tos/deploy-cluster) to deploy and verify. The first deployment takes at least 30 minutes (about 10 for the EKS control plane, then ArgoCD syncing).
 
 **After deploy**, DNS handling depends on which config you chose: `aws-config.yaml` requires a manual A/CNAME record; `aws-config-with-dns.yaml` creates DNS records automatically. See [DNS](/docs/how-tos/deploy#dns) in the deploy lifecycle guide for details.
+
+:::note
+Verifying on AWS also needs the [AWS CLI](https://aws.amazon.com/cli/) — the generated kubeconfig calls `aws eks get-token` to authenticate. If `kubectl` fails with `Token has expired and refresh failed`, your AWS SSO session timed out (default 8 hours); run `aws sso login --profile <aws-profile>` and retry.
+:::
 
 ## IAM roles `nic` creates in your account
 
@@ -164,29 +168,6 @@ Run the deploy commands as described in [Deploy](/docs/how-tos/deploy#deploy) in
 | AWS Load Balancer Controller role | Lets the in-cluster controller create and manage load balancers for ingress. |
 | EBS CSI driver role | Lets the in-cluster driver mount EBS volumes into pods. |
 | EFS CSI driver role (if EFS enabled) | Lets the in-cluster driver mount EFS into pods. |
-
-## Verify
-
-:::note
-The steps below use [`kubectl`](https://kubernetes.io/docs/tasks/tools/) and the [AWS CLI](https://aws.amazon.com/cli/). Install them if you don't have them.
-:::
-
-After `nic deploy` returns, point your kubectl at the cluster:
-
-```bash
-nic kubeconfig -f <config-file> -o ~/.kube/nebari.yaml
-export KUBECONFIG=~/.kube/nebari.yaml
-```
-
-Substitute `<config-file>` with the local config you created earlier (e.g., `aws-config.yaml`).
-
-`KUBECONFIG` tells `kubectl` to read `~/.kube/nebari.yaml`, a standalone kubeconfig for this cluster, instead of the default. Add this line to your shell rc to persist.
-
-Then follow the [Verify](/docs/how-tos/deploy#verify) steps in the deploy lifecycle guide to check the cluster and ArgoCD applications.
-
-:::note
-If `kubectl` fails with `Token has expired and refresh failed`, your AWS SSO session timed out (default 8 hours). Re-authenticate with `aws sso login --profile <aws-profile>` and retry.
-:::
 
 ## First sign-in
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -43,6 +43,7 @@ module.exports = {
       link: { type: "doc", id: "how-tos/index" },
       items: [
         "how-tos/deploy",
+        "how-tos/deploy-cluster",
         {
           type: "category",
           label: "Providers",


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #689.

## What does this implement/fix?

- Adds a dedicated **Deploy a cluster** how-to covering the provider-agnostic deploy-and-verify flow: configuration, `nic deploy`, retrieving a kubeconfig, and verifying the cluster.
- Documents the **Retrieve the kubeconfig** step (`nic kubeconfig`) that the lifecycle page previously assumed but never showed, so the verify commands are actually runnable.
- Slims the deploy lifecycle page to link out to the new page (it keeps GitOps setup, DNS, first sign-in, update, and destroy) and routes the AWS provider page to it from a single Deploy and verify section.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Ran the Docusaurus build (no new broken links), verified `nic validate` and the `nic kubeconfig` flags against a real `nic` install, and confirmed the AWS CLI and `aws eks get-token` claims against the `nic` source.
