### PR TITLE
docs: add a Destroy a cluster page

### DIFF
--- a/docs/docs/how-tos/deploy.mdx
+++ b/docs/docs/how-tos/deploy.mdx
@@ -134,20 +134,4 @@ Some config fields trigger destructive resource recreation when changed. Check y
 
 ## Destroy
 
-When you're done with the cluster, tear it down with `nic destroy`. Run a dry-run first to see what will be removed:
-
-```bash
-# Preview what will be destroyed.
-nic destroy -f <config-file> --dry-run
-
-# Tear down everything nic created.
-nic destroy -f <config-file>
-```
-
-If a resource fails to delete and `nic destroy` exits with an error, retry with `--force`:
-
-```bash
-nic destroy -f <config-file> --force
-```
-
-Always confirm in your cloud provider's console that no orphan resources remain after destroy. See your provider's page for provider-specific cleanup notes.
+When you're done with the cluster, tear it down with `nic destroy`: see [Destroy a cluster](/docs/how-tos/destroy-cluster).

--- a/docs/docs/how-tos/destroy-cluster.mdx
+++ b/docs/docs/how-tos/destroy-cluster.mdx
@@ -1,0 +1,42 @@
+---
+title: Destroy a cluster
+slug: /how-tos/destroy-cluster
+description: "Tear down an NKP cluster with nic destroy: dry-run, teardown order, retrying with --force, and checking for orphan resources."
+---
+
+When you're done with a cluster, tear it down with `nic destroy`. These steps are the same across all providers; see your [provider's page](/docs/how-tos/providers) for provider-specific cleanup notes.
+
+## Destroy
+
+Run a dry-run first to see what will be removed, then destroy:
+
+```bash
+# Preview what will be destroyed; no resources are removed.
+nic destroy -f <config-file> --dry-run
+
+# Tear down everything nic created (prompts for confirmation first).
+nic destroy -f <config-file>
+```
+
+`nic destroy` prompts for confirmation before removing anything. Pass `--auto-approve` to skip the prompt in automation.
+
+If a resource fails to delete and `nic destroy` exits with an error, retry with `--force` to continue past errors instead of aborting:
+
+```bash
+nic destroy -f <config-file> --force
+```
+
+## Order of teardown
+
+`nic destroy` tears things down in this order:
+
+1. Validates your config and selects the provider.
+2. Prompts for confirmation (skipped with `--auto-approve` or `--dry-run`).
+3. Cleans up DNS records, if a DNS provider is configured.
+4. Destroys the cluster infrastructure.
+
+A `--dry-run` previews the changes without removing anything, including DNS records.
+
+## Check for orphan resources
+
+Always confirm in your cloud provider's console that no orphan resources remain after destroy. Resources that bill hourly (load balancers, NAT gateways, volumes) are worth checking first. See your [provider's page](/docs/how-tos/providers) for provider-specific cleanup notes.

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -202,7 +202,7 @@ Changing `region`, `project_name`, or `vpc_cidr_block` triggers destructive reso
 
 ## Destroy
 
-Run the destroy commands as described in [Destroy](/docs/how-tos/deploy#destroy) in the deploy lifecycle guide.
+Run the destroy commands as described in [Destroy a cluster](/docs/how-tos/destroy-cluster).
 
 `nic destroy` removes EKS, node groups, EFS, VPC components, and the state bucket. If a resource fails to delete (commonly, a leftover load balancer from the cluster's ingress), remove it manually in the AWS console before retrying with `--force`.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -43,6 +43,7 @@ module.exports = {
       link: { type: "doc", id: "how-tos/index" },
       items: [
         "how-tos/deploy",
+        "how-tos/destroy-cluster",
         {
           type: "category",
           label: "Providers",


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #657.

## What does this implement/fix?

- Adds a dedicated **Destroy a cluster** how-to covering the provider-agnostic teardown.
- Documents the **order of teardown** (confirm, then DNS cleanup, then infrastructure), which the lifecycle page did not cover, so a reader knows what state a partial or failed destroy leaves behind.
- Slims the deploy lifecycle page to link out to the new page and points the AWS provider page at it.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Ran the Docusaurus build (no new broken links) and verified the teardown order, confirmation prompt, and `--auto-approve` / `--force` behavior against the `nic` source (`pkg/nic/destroy.go`, `cmd/nic/destroy.go`).
