### PR TITLE
docs: add an Update a cluster page

### DIFF
--- a/docs/docs/how-tos/deploy.mdx
+++ b/docs/docs/how-tos/deploy.mdx
@@ -119,18 +119,7 @@ For an interactive view of all cluster resources (especially handy while watchin
 
 ## Update an existing deployment
 
-To change something about a running cluster, edit your config and re-run:
-
-```bash
-nic deploy -f <config-file> --dry-run    # verify config resolves; no resources changed
-nic deploy -f <config-file>              # apply it
-```
-
-`nic` is declarative, so only the diff is applied.
-
-:::warning
-Some config fields trigger destructive resource recreation when changed. Check your provider's page for which fields these are.
-:::
+To change a running cluster, edit your config and re-run `nic deploy`: see [Update a cluster](/docs/how-tos/update-cluster).
 
 ## Destroy
 

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -194,7 +194,7 @@ See [First sign-in](/docs/how-tos/deploy#first-sign-in) in the deploy lifecycle 
 
 ## Update an existing deployment
 
-To change something about a running cluster (scale a node group, add a `gpu` group, change tags, switch EFS throughput), edit your config and re-run the deploy commands as described in [Update an existing deployment](/docs/how-tos/deploy#update-an-existing-deployment) in the deploy lifecycle guide.
+To change something about a running cluster (scale a node group, add a `gpu` group, change tags, switch EFS throughput), edit your config and re-run the deploy commands as described in [Update a cluster](/docs/how-tos/update-cluster).
 
 :::warning
 Changing `region`, `project_name`, or `vpc_cidr_block` triggers destructive resource recreation. Treat these as one-way decisions.

--- a/docs/docs/how-tos/update-cluster.mdx
+++ b/docs/docs/how-tos/update-cluster.mdx
@@ -1,0 +1,27 @@
+---
+title: Update a cluster
+slug: /how-tos/update-cluster
+description: "Apply configuration changes to a running NKP cluster by re-running nic deploy, which reconciles the cluster to match your config."
+---
+
+To change a running cluster, edit your config and re-run `nic deploy`. `nic` is declarative: it compares your config against the cluster's current state and applies only the difference. These steps are the same across all providers; see your [provider's page](/docs/how-tos/providers) for provider-specific fields.
+
+## Apply a change
+
+Most changes, such as scaling a node group, adding a node group, or changing tags, update the cluster without recreating it. Preview the change first, then apply it:
+
+```bash
+nic deploy -f <config-file> --dry-run    # show what would change; nothing is modified
+nic deploy -f <config-file>              # apply it
+```
+
+## Immutable fields
+
+Some fields (cluster identity, network foundation) can't be changed on a running cluster. Changing one requires destroying and recreating it. The exact fields are provider-specific: see your [provider's page](/docs/how-tos/providers).
+
+## Reconcile drift
+
+If something is changed outside `nic` (for example, in your cloud provider's console), the cluster drifts from your config. To reconcile:
+
+- **Preview:** `nic deploy --dry-run` shows which resources drifted and how `nic` will fix them.
+- **Apply:** `nic deploy` updates them back to your config.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -43,6 +43,7 @@ module.exports = {
       link: { type: "doc", id: "how-tos/index" },
       items: [
         "how-tos/deploy",
+        "how-tos/update-cluster",
         {
           type: "category",
           label: "Providers",


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #658.

## What does this implement/fix?

- Adds a dedicated **Update a cluster** how-to: applying changes by re-running `nic deploy` (declarative, so only the diff is applied), which settings are immutable, and how to reconcile drift.
- Slims the deploy lifecycle page to link out to the new page and points the AWS provider page at it.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Ran the Docusaurus build (no new broken links) and verified the drift/reconcile behavior against the `nic` source (`pkg/tofu/tofu.go`) and the audited state-management design doc; immutable-field specifics are deferred to the provider page.
