### PR TITLE
docs: add a Cloudflare DNS page

### DIFF
--- a/docs/docs/how-tos/cloudflare-dns.mdx
+++ b/docs/docs/how-tos/cloudflare-dns.mdx
@@ -43,3 +43,5 @@ Without Cloudflare, `nic` prints the load balancer's IP or hostname at the end o
 - `*.<domain>`
 
 Use an **A** record for an IP or a **CNAME** for a hostname. The cluster is not reachable over HTTPS until they propagate.
+
+For the full `dns` configuration schema, see the [NIC configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#dns-provider-configuration).

--- a/docs/docs/how-tos/cloudflare-dns.mdx
+++ b/docs/docs/how-tos/cloudflare-dns.mdx
@@ -1,0 +1,45 @@
+---
+title: Cloudflare DNS
+slug: /how-tos/cloudflare-dns
+description: "Configure DNS for an NKP cluster: let nic manage Cloudflare records automatically, or create records manually with any DNS provider."
+---
+
+After deploy, your cluster needs DNS records so its services resolve over HTTPS. `nic` can manage these automatically through Cloudflare, or you can create them manually with any DNS provider.
+
+## Cloudflare (automatic)
+
+:::note
+These go in the `.env` and provider config from your [provider's page](/docs/how-tos/providers), before you run `nic deploy`.
+:::
+
+1. [Generate a Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with **Zone:Read** and **DNS:Edit** permissions on your domain's zone, and add it to the `.env` in the directory you deploy from:
+
+   ```bash
+   CLOUDFLARE_API_TOKEN=...
+   ```
+
+2. Set the zone in your provider config file (for example, `aws-config.yaml`), using the parent zone of your `domain`:
+
+   ```yaml
+   dns:
+     cloudflare:
+       zone_name: example.com
+   ```
+
+Once the load balancer endpoint is ready, `nic` creates two records pointing at it:
+
+- `<domain>`: your cluster's domain.
+- `*.<domain>`: a wildcard so subdomains like `keycloak.<domain>` resolve.
+
+:::warning[Changing the domain leaves old records behind]
+If you change `domain` and redeploy, `nic` creates the new records but leaves the old domain's records in place. Delete them yourself in Cloudflare.
+:::
+
+## Other DNS providers (manual)
+
+Without Cloudflare, `nic` prints the load balancer's IP or hostname at the end of deploy. Create two records at your DNS provider, both pointing at it:
+
+- `<domain>`
+- `*.<domain>`
+
+Use an **A** record for an IP or a **CNAME** for a hostname. The cluster is not reachable over HTTPS until they propagate.

--- a/docs/docs/how-tos/deploy.mdx
+++ b/docs/docs/how-tos/deploy.mdx
@@ -31,10 +31,7 @@ Download a starter config, validate it, provision the cluster, retrieve a kubeco
 
 ## DNS
 
-After deploy completes, your cluster needs a DNS record to be reachable:
-
-- **Cloudflare-managed domains:** add `CLOUDFLARE_API_TOKEN` to your `.env` with `Zone:DNS:Edit` permission on your domain's zone. `nic` creates the record automatically.
-- **All other DNS providers:** `nic` prints the load balancer's IP address or hostname at the end of deploy. Create an **A/CNAME record** at your DNS provider pointing your domain to that value. The cluster will not be reachable over HTTPS until the record propagates.
+After deploy completes, your cluster needs DNS records to be reachable: see [Cloudflare DNS](/docs/how-tos/cloudflare-dns).
 
 ## First sign-in
 

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -142,7 +142,7 @@ dns:
 ```
 
 :::note[Cloudflare DNS]
-To use `aws-config-with-dns.yaml`, [generate a Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with `Zone:Read` and `DNS:Edit` permissions on the zone in `dns.cloudflare.zone_name`. See [DNS](/docs/how-tos/deploy#dns) in the deploy lifecycle guide for how to add it to `.env`.
+To use `aws-config-with-dns.yaml`, [generate a Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with `Zone:Read` and `DNS:Edit` permissions on the zone in `dns.cloudflare.zone_name`. See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for how to add it to `.env`.
 :::
 
 For the full schema (brownfield VPC adoption, custom KMS keys, advanced node-group options, Longhorn, log types), see the [NIC configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md).
@@ -151,7 +151,7 @@ For the full schema (brownfield VPC adoption, custom KMS keys, advanced node-gro
 
 Follow [Deploy a cluster](/docs/how-tos/deploy-cluster) to deploy and verify. The first deployment takes at least 30 minutes (about 10 for the EKS control plane, then ArgoCD syncing).
 
-**After deploy**, DNS handling depends on which config you chose: `aws-config.yaml` requires a manual A/CNAME record; `aws-config-with-dns.yaml` creates DNS records automatically. See [DNS](/docs/how-tos/deploy#dns) in the deploy lifecycle guide for details.
+**After deploy**, DNS handling depends on which config you chose: `aws-config.yaml` requires a manual A/CNAME record; `aws-config-with-dns.yaml` creates DNS records automatically. See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for details.
 
 :::note
 Verifying on AWS also needs the [AWS CLI](https://aws.amazon.com/cli/) — the generated kubeconfig calls `aws eks get-token` to authenticate. If `kubectl` fails with `Token has expired and refresh failed`, your AWS SSO session timed out (default 8 hours); run `aws sso login --profile <aws-profile>` and retry.

--- a/docs/docs/how-tos/providers/hetzner.mdx
+++ b/docs/docs/how-tos/providers/hetzner.mdx
@@ -123,7 +123,7 @@ For the full schema (autoscaling, `persist_data`, Longhorn options), see the [NI
 Run the deploy commands as described in [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) in the deploy lifecycle guide. Allow 10–15 minutes for the first deployment — k3s cluster creation followed by ArgoCD syncing foundational services.
 
 
-See [DNS](/docs/how-tos/deploy#dns) in the deploy lifecycle guide for DNS setup (Cloudflare or manual A record). For full DNS configuration options, see the [NIC DNS configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#dns-provider-configuration).
+See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for DNS setup (Cloudflare or manual A record). For full DNS configuration options, see the [NIC DNS configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#dns-provider-configuration).
 
 ## Verify
 

--- a/docs/docs/how-tos/providers/hetzner.mdx
+++ b/docs/docs/how-tos/providers/hetzner.mdx
@@ -123,7 +123,7 @@ For the full schema (autoscaling, `persist_data`, Longhorn options), see the [NI
 Run the deploy commands as described in [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) in the deploy lifecycle guide. Allow 10–15 minutes for the first deployment — k3s cluster creation followed by ArgoCD syncing foundational services.
 
 
-See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for DNS setup (Cloudflare or manual A record). For full DNS configuration options, see the [NIC DNS configuration reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#dns-provider-configuration).
+See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for DNS setup (Cloudflare or manual A record).
 
 ## Verify
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -45,6 +45,7 @@ module.exports = {
         "how-tos/prepare-to-deploy",
         "how-tos/deploy",
         "how-tos/deploy-cluster",
+        "how-tos/cloudflare-dns",
         "how-tos/update-cluster",
         "how-tos/destroy-cluster",
         {


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #654.

## What does this implement/fix?

- Adds a dedicated **Cloudflare DNS** how-to covering the automatic Cloudflare path (API token, `zone_name` config, and which records `nic` creates and when) and the manual path for any other DNS provider.
- Documents the known limitation that changing `domain` and redeploying leaves the old domain's records behind, which the lifecycle page did not mention.
- Slims the deploy lifecycle page to link out to the new page and points the AWS and Hetzner provider pages at it.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Ran the Docusaurus build (no new broken links) and verified the records, token permissions, and domain-change limitation against the audited DNS design doc and a live deploy (`nic` created an apex and wildcard Cloudflare record after the load balancer endpoint was ready).
