### PR TITLE
docs: add a Keycloak authentication page

### DIFF
--- a/docs/docs/how-tos/deploy.mdx
+++ b/docs/docs/how-tos/deploy.mdx
@@ -38,17 +38,7 @@ After deploy completes, your cluster needs a DNS record to be reachable:
 
 ## First sign-in
 
-`nic` does not create an end-user account, so create one in Keycloak before you can sign in:
-
-1. Get the Keycloak admin credentials:
-   ```bash
-   kubectl -n keycloak get secret keycloak-admin-credentials -o json | jq '.data | map_values(@base64d)'
-   ```
-2. Open `https://keycloak.<your-domain>/auth/admin/` and sign in with those credentials.
-3. Switch the realm dropdown (top-left) from `master` to `nebari`.
-4. Go to **Users → Add user**, set a username and email, and save.
-5. On the user's **Credentials** tab, click **Set password**, enter one, and uncheck **Temporary**.
-6. Visit `https://<your-domain>` and sign in with the new user. You should land on the Launchpad.
+`nic` does not create an end-user account, so create one in Keycloak before you can sign in: see [Keycloak authentication](/docs/how-tos/keycloak-auth).
 
 ## Update an existing deployment
 

--- a/docs/docs/how-tos/keycloak-auth.mdx
+++ b/docs/docs/how-tos/keycloak-auth.mdx
@@ -1,0 +1,75 @@
+---
+title: Keycloak authentication
+slug: /how-tos/keycloak-auth
+description: "How NKP uses Keycloak for single sign-on: the operator wires it up automatically, and you manage users, groups, and access in the nebari realm."
+---
+
+NKP uses [Keycloak](https://www.keycloak.org/) for single sign-on across all cluster services. The Nebari Operator wires Keycloak up for you, so day to day you mostly manage users and groups, not client configuration.
+
+## Single sign-on
+
+Single sign-on is wired into every app for you.
+
+When a pack installs, NKP reads its [`NebariApp`](/docs/explanations/software-packs#the-nebariapp-resource) and sets up its login, so it appears on the Launchpad with platform-account sign-in.
+
+In Keycloak you manage only **users and groups**. Per-app auth lives in the `NebariApp`.
+
+## Admin access
+
+The admin account has full control over Keycloak: create and manage users, organize them into groups, and adjust realm settings. You'll use it for the rest of this guide.
+
+To sign in to the admin console:
+
+1. Get the Keycloak admin credentials:
+
+   ```bash
+   kubectl -n keycloak get secret keycloak-admin-credentials -o json | jq '.data | map_values(@base64d)'
+   ```
+
+2. Open `https://keycloak.<your-domain>/auth/admin/` and sign in with those credentials.
+3. Switch the realm dropdown (top-left) from `master` to `nebari`.
+
+## Create your first user
+
+`nic` does not create an end-user account, so create one before you can sign in:
+
+1. In the `nebari` realm, go to **Users → Add user**, set a username and email, and save.
+2. On the user's **Credentials** tab, click **Set password**, enter one, and uncheck **Temporary**.
+3. Visit `https://<your-domain>` and sign in with the new user. You should land on the Launchpad.
+
+## Users, groups, and access
+
+Apps can restrict access to specific **groups**, enforced at the gateway from each user's `groups` claim. To let someone into a restricted app, add them to the group it requires.
+
+Manage this in the `nebari` realm:
+
+- **Groups → Create group** to add a group, then assign members on the group's **Members** tab (or from a user's **Groups** tab).
+- An app that doesn't restrict by group is open to any signed-in user.
+
+## Customizing per app
+
+You can define an app's access in its `NebariApp` manifest instead of the console. Because the manifest is in Git, the access rules are version-controlled and reviewed like code:
+
+```yaml
+spec:
+  auth:
+    enabled: true
+    provider: keycloak
+    groups:
+      - data-scientists          # groups allowed to use the app
+    enforceAtGateway: true       # enforce group membership at the gateway
+    keycloakConfig:
+      groups:
+        - name: data-scientists  # create the group in the nebari realm and add members
+          members:
+            - alice
+            - bob
+```
+
+- `groups` lists the groups allowed to use the app.
+- `enforceAtGateway: true` blocks users outside those groups at the gateway. Without it, group membership isn't enforced.
+- `keycloakConfig.groups` creates those groups in the `nebari` realm and adds the listed members.
+
+The operator reconciles all of this on the next deploy. For one-off changes, edit groups and memberships directly in the admin console.
+
+For all `spec.auth` fields, see the [NebariApp configuration reference](https://github.com/nebari-dev/nebari-operator/blob/main/docs/configuration-reference.md#auth).

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -171,7 +171,7 @@ Verifying on AWS also needs the [AWS CLI](https://aws.amazon.com/cli/) — the g
 
 ## First sign-in
 
-See [First sign-in](/docs/how-tos/deploy#first-sign-in) in the deploy lifecycle guide.
+See [Keycloak authentication](/docs/how-tos/keycloak-auth) for first sign-in.
 
 ## Update an existing deployment
 

--- a/docs/docs/how-tos/providers/hetzner.mdx
+++ b/docs/docs/how-tos/providers/hetzner.mdx
@@ -138,7 +138,7 @@ Then follow the [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) step
 
 ## First sign-in
 
-See [First sign-in](/docs/how-tos/deploy#first-sign-in) in the deploy lifecycle guide.
+See [Keycloak authentication](/docs/how-tos/keycloak-auth) for first sign-in.
 
 ## Update an existing deployment
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -47,6 +47,7 @@ module.exports = {
         "how-tos/deploy-cluster",
         "how-tos/update-cluster",
         "how-tos/destroy-cluster",
+        "how-tos/keycloak-auth",
         {
           type: "category",
           label: "Providers",


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #656.

## What does this implement/fix?

- Adds a dedicated **Keycloak authentication** how-to: how single sign-on is wired into each app for you, admin console access, creating the first user, and managing users and groups in the `nebari` realm.
- Documents how to gate an app by group, both in the Keycloak console and declaratively in the app's `NebariApp` (`spec.auth`), with the access enforced at the gateway.
- Slims the deploy lifecycle page to link out to the new page and points the AWS and Hetzner provider pages at it.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Verified the operator's Keycloak wiring and `spec.auth` fields against the `nebari-operator` source, and confirmed the admin console navigation (Groups, Create group, Members tab, user Groups tab) against a live Keycloak 26.5.0, the version a deploy installs.
