### PR TITLE
docs(references): render config schema from the NIC JSON Schema (PoC)

### DIFF
--- a/docs/docs/config-builder.mdx
+++ b/docs/docs/config-builder.mdx
@@ -21,12 +21,10 @@ Pick a cloud provider, set the always-required fields, and copy a starter
 the full set of options lives in the
 [Configuration schema](/docs/references/config-schema) reference.
 
-<NicConfigBuilder />
+## Before you deploy
 
-## Next steps
-
-The generated file is a **starting point**, not a finished config. Before you
-deploy:
+The file this builder generates is a **starting point**, not a finished config.
+Before you deploy:
 
 - Validate it with `nic validate -f nebari-config.yaml`, which checks it against
   the schema the CLI actually accepts.
@@ -40,3 +38,5 @@ DNS credentials (for example a Cloudflare API token) are read from environment
 variables at deploy time, not stored in this file. The builder only sets the
 `zone_id` that selects which zone to manage.
 :::
+
+<NicConfigBuilder />

--- a/docs/docs/config-builder.mdx
+++ b/docs/docs/config-builder.mdx
@@ -9,6 +9,13 @@ import NicConfigBuilder from '@site/src/components/NicConfigBuilder';
 
 # Config builder
 
+:::warning Work in progress
+This builder UI is a work in progress; most combinations are not yet wired into
+the form below. If you hit a "not yet wired in this UI" notice, or need anything
+beyond what is exposed here, write the YAML by hand using the
+[configuration schema](/docs/references/config-schema) for the full schema.
+:::
+
 Pick a cloud provider, set the always-required fields, and copy a starter
 `nebari-config.yaml` to begin from. This covers the minimum a deployment needs;
 the full set of options lives in the

--- a/docs/docs/config-builder.mdx
+++ b/docs/docs/config-builder.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Config builder'
+id: config-builder
+description: 'Generate a starter nebari-config.yaml: pick a cloud and DNS provider, set the required fields, and copy the result.'
+hide_table_of_contents: true
+---
+
+import NicConfigBuilder from '@site/src/components/NicConfigBuilder';
+
+# Config builder
+
+Pick a cloud provider, set the always-required fields, and copy a starter
+`nebari-config.yaml` to begin from. This covers the minimum a deployment needs;
+the full set of options lives in the
+[Configuration schema](/docs/references/config-schema) reference.
+
+<NicConfigBuilder />
+
+## Next steps
+
+The generated file is a **starting point**, not a finished config. Before you
+deploy:
+
+- Validate it with `nic validate -f nebari-config.yaml`, which checks it against
+  the schema the CLI actually accepts.
+- Fill in any provider-specific and optional fields (networking, storage,
+  authentication, backups) from the [Configuration schema](/docs/references/config-schema).
+- Follow [Prepare to deploy](/docs/how-tos/prepare-to-deploy) and
+  [Deploy](/docs/how-tos/deploy) to bring the cluster up.
+
+:::note
+DNS credentials (for example a Cloudflare API token) are read from environment
+variables at deploy time, not stored in this file. The builder only sets the
+`zone_id` that selects which zone to manage.
+:::

--- a/docs/docs/references/config-schema.mdx
+++ b/docs/docs/references/config-schema.mdx
@@ -1,0 +1,17 @@
+---
+title: 'Configuration schema'
+id: config-schema
+description: 'Auto-generated reference for the nebari-config.yaml schema, rendered from the NIC JSON Schema.'
+---
+
+import NicSchemaLoader from '@site/src/components/NicSchemaLoader';
+
+# Configuration schema
+
+The Nebari Infrastructure Core (NIC) configuration file (`nebari-config.yaml`)
+is validated against a JSON Schema generated directly from the Go config structs
+in [`nebari-infrastructure-core`](https://github.com/nebari-dev/nebari-infrastructure-core).
+The reference below is loaded from that schema at build time, so it always
+matches the config the CLI actually accepts.
+
+<NicSchemaLoader />

--- a/docs/docs/references/config-schema.mdx
+++ b/docs/docs/references/config-schema.mdx
@@ -2,6 +2,7 @@
 title: 'Configuration schema'
 id: config-schema
 description: 'Auto-generated reference for the nebari-config.yaml schema, rendered from the NIC JSON Schema.'
+hide_table_of_contents: true
 ---
 
 import NicSchemaLoader from '@site/src/components/NicSchemaLoader';

--- a/docs/package.json
+++ b/docs/package.json
@@ -53,6 +53,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
+    "remark-gfm": "^3.0.1",
     "sass": "^1.77.8",
     "vanilla-cookieconsent": "^3.1.0"
   },

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -72,6 +72,7 @@ module.exports = {
       link: { type: "doc", id: "references/index" },
       items: [
         "references/personas",
+        "references/config-schema",
       ],
     },
     {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -29,6 +29,11 @@ module.exports = {
       ],
     },
     {
+      type: "doc",
+      id: "config-builder",
+      label: "Config builder",
+    },
+    {
       type: "category",
       label: "Explanations",
       link: { type: "doc", id: "explanations/index" },

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -1,6 +1,6 @@
 import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import styles from './styles.module.css';
 
@@ -185,6 +185,23 @@ function buildYaml(s: BuilderState): string {
   return `${lines.join('\n')}\n`;
 }
 
+// URL-safe encoding of the builder state, so a link reproduces the exact form a
+// user built. Called only in the browser (guarded by callers).
+function encodeState(s: BuilderState): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(s));
+  let bin = '';
+  bytes.forEach((b) => {
+    bin += String.fromCharCode(b);
+  });
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function decodeState(param: string): Partial<BuilderState> {
+  const b64 = param.replace(/-/g, '+').replace(/_/g, '/');
+  const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes)) as Partial<BuilderState>;
+}
+
 // A labelled control: human label + the schema key it maps to, above the input.
 function LabeledField({
   label,
@@ -225,9 +242,57 @@ function Section({ label, children }: { label: string; children: React.ReactNode
 
 export default function NicConfigBuilder(): JSX.Element {
   const [state, setState] = useState<BuilderState>(() => initialFor('aws'));
+  const [modalOpen, setModalOpen] = useState(false);
+  const [copiedLink, setCopiedLink] = useState(false);
   const meta = PROVIDERS[state.provider];
   const yaml = useMemo(() => buildYaml(state), [state]);
   const isHetzner = meta.nodeShape === 'hetzner';
+
+  // Restore state from a shared link and show the config front-and-centre.
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const c = new URLSearchParams(window.location.search).get('c');
+    if (!c) {
+      return;
+    }
+    try {
+      const decoded = decodeState(c);
+      setState((prev) => ({ ...prev, ...decoded }));
+      setModalOpen(true);
+    } catch {
+      /* ignore malformed share links */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!modalOpen) {
+      return undefined;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setModalOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [modalOpen]);
+
+  const shareUrl =
+    typeof window === 'undefined'
+      ? ''
+      : `${window.location.origin}${window.location.pathname}?c=${encodeState(state)}`;
+
+  const copyLink = () => {
+    try {
+      navigator.clipboard.writeText(shareUrl);
+    } catch {
+      /* clipboard unavailable */
+    }
+    setCopiedLink(true);
+    setTimeout(() => setCopiedLink(false), 1600);
+  };
 
   const set = <K extends keyof BuilderState>(key: K, value: BuilderState[K]) =>
     setState((prev) => ({ ...prev, [key]: value }));
@@ -549,6 +614,9 @@ export default function NicConfigBuilder(): JSX.Element {
           <div className={styles.outputHead}>
             <span className={styles.outputTitle}>nebari-config.yaml</span>
             <span className={styles.spacer} />
+            <button type="button" className={styles.btn} onClick={() => setModalOpen(true)}>
+              Share
+            </button>
             <button type="button" className={styles.btn} onClick={download}>
               Download
             </button>
@@ -556,6 +624,44 @@ export default function NicConfigBuilder(): JSX.Element {
           <CodeBlock language="yaml">{yaml}</CodeBlock>
         </div>
       </div>
+
+      {modalOpen && (
+        <div className={styles.overlay} onClick={() => setModalOpen(false)}>
+          <div
+            className={styles.dialog}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Generated configuration"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className={styles.dialogHead}>
+              <span className={styles.outputTitle}>nebari-config.yaml</span>
+              <span className={styles.spacer} />
+              <button type="button" className={styles.btn} onClick={download}>
+                Download
+              </button>
+              <button
+                type="button"
+                className={styles.btn}
+                onClick={() => setModalOpen(false)}
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+            <div className={styles.dialogBody}>
+              <CodeBlock language="yaml">{yaml}</CodeBlock>
+            </div>
+            <div className={styles.shareRow}>
+              <span className={styles.shareLabel}>Share link</span>
+              <input className={styles.input} readOnly value={shareUrl} onFocus={(e) => e.target.select()} />
+              <button type="button" className={styles.btn} onClick={copyLink}>
+                {copiedLink ? 'Copied' : 'Copy link'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -281,9 +281,9 @@ export default function NicConfigBuilder(): JSX.Element {
 
   return (
     <div className={styles.wrapper}>
-      {providerCards}
       <div className={styles.builder}>
         <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+          {providerCards}
           <Section label="Deployment">
             <div className={styles.grid2}>
               <LabeledField label="Project name" schemaKey="project_name" required>

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -1,6 +1,7 @@
 import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
 import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import styles from './styles.module.css';
 
@@ -798,7 +799,9 @@ export default function NicConfigBuilder(): JSX.Element {
         </div>
       </div>
 
-      {modalOpen && (
+      {modalOpen &&
+        typeof document !== 'undefined' &&
+        createPortal(
         <div className={styles.overlay} onClick={() => setModalOpen(false)}>
           <div
             className={styles.dialog}
@@ -838,8 +841,9 @@ export default function NicConfigBuilder(): JSX.Element {
               </button>
             </div>
           </div>
-        </div>
-      )}
+        </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -1,3 +1,4 @@
+import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
 import React, { useMemo, useState } from 'react';
 
@@ -16,9 +17,14 @@ type ProviderKey = 'aws' | 'gcp' | 'azure' | 'hetzner';
 
 type ProviderMeta = {
   label: string;
-  regionLabel: string;
-  regions: string[];
-  instances: string[];
+  // `stub: true` means the cloud is supported by NIC but not yet wired into this
+  // builder; its tab shows a hand-off notice instead of a form. To enable a
+  // provider, drop `stub` and fill regionLabel/regions/instances with values
+  // confirmed against the schema (do not guess).
+  stub?: boolean;
+  regionLabel?: string;
+  regions?: string[];
+  instances?: string[];
 };
 
 const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
@@ -28,24 +34,9 @@ const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
     regions: ['us-west-2', 'us-east-1', 'eu-west-1', 'ap-southeast-2'],
     instances: ['m5.large', 'm5.xlarge', 'm5.2xlarge'],
   },
-  gcp: {
-    label: 'GCP',
-    regionLabel: 'region',
-    regions: ['us-central1', 'us-east1', 'europe-west1'],
-    instances: ['e2-standard-4', 'n2-standard-4', 'n2-standard-8'],
-  },
-  azure: {
-    label: 'Azure',
-    regionLabel: 'region',
-    regions: ['eastus', 'westeurope', 'australiaeast'],
-    instances: ['Standard_D4s_v5', 'Standard_D8s_v5'],
-  },
-  hetzner: {
-    label: 'Hetzner',
-    regionLabel: 'location',
-    regions: ['nbg1', 'fsn1', 'hel1'],
-    instances: ['cpx31', 'cpx41', 'cpx51'],
-  },
+  gcp: { label: 'GCP', stub: true },
+  azure: { label: 'Azure', stub: true },
+  hetzner: { label: 'Hetzner', stub: true },
 };
 
 type BuilderState = {
@@ -67,11 +58,11 @@ const initialFor = (provider: ProviderKey): BuilderState => ({
   provider,
   projectName: 'my-nebari',
   domain: 'nebari.example.com',
-  region: PROVIDERS[provider].regions[0],
+  region: PROVIDERS[provider].regions?.[0] ?? '',
   certType: 'lets-encrypt',
   acmeEmail: 'admin@example.com',
   nodeGroupName: 'general',
-  instance: PROVIDERS[provider].instances[0],
+  instance: PROVIDERS[provider].instances?.[0] ?? '',
   minNodes: 1,
   maxNodes: 5,
   useCloudflare: true,
@@ -125,29 +116,51 @@ export default function NicConfigBuilder(): JSX.Element {
     setState((prev) => ({
       ...prev,
       provider,
-      region: PROVIDERS[provider].regions[0],
-      instance: PROVIDERS[provider].instances[0],
+      region: PROVIDERS[provider].regions?.[0] ?? '',
+      instance: PROVIDERS[provider].instances?.[0] ?? '',
     }));
 
-  return (
-    <div className={styles.builder}>
-      <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
-        <fieldset className={styles.group}>
-          <legend className={styles.legend}>Cloud provider</legend>
-          <div className={styles.pills}>
-            {(Object.keys(PROVIDERS) as ProviderKey[]).map((key) => (
-              <button
-                key={key}
-                type="button"
-                className={`${styles.pill} ${state.provider === key ? styles.pillActive : ''}`}
-                onClick={() => changeProvider(key)}
-              >
-                {PROVIDERS[key].label}
-              </button>
-            ))}
-          </div>
-        </fieldset>
+  const providerSelector = (
+    <fieldset className={styles.group}>
+      <legend className={styles.legend}>Cloud provider</legend>
+      <div className={styles.pills}>
+        {(Object.keys(PROVIDERS) as ProviderKey[]).map((key) => (
+          <button
+            key={key}
+            type="button"
+            className={`${styles.pill} ${state.provider === key ? styles.pillActive : ''}`}
+            onClick={() => changeProvider(key)}
+          >
+            {PROVIDERS[key].label}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
 
+  // A supported cloud that this builder does not yet cover: hand the reader off
+  // to the schema reference rather than emitting a half-guessed config.
+  if (meta.stub) {
+    return (
+      <div className={styles.wrapper}>
+        {providerSelector}
+        <div className={styles.stub}>
+          <p>
+            Nebari supports {meta.label}, but it is not yet wired into this UI. Write the
+            YAML by hand using the{' '}
+            <Link to="/docs/references/config-schema">configuration schema</Link> for the
+            full set of fields.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      {providerSelector}
+      <div className={styles.builder}>
+      <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
         <div className={styles.row}>
           <label className={styles.field}>
             <span className={styles.label}>project_name</span>
@@ -170,14 +183,14 @@ export default function NicConfigBuilder(): JSX.Element {
         <div className={styles.row}>
           <label className={styles.field}>
             <span className={styles.label}>
-              cluster.{state.provider}.{meta.regionLabel}
+              cluster.{state.provider}.{meta.regionLabel ?? 'region'}
             </span>
             <select
               className={styles.input}
               value={state.region}
               onChange={(e) => set('region', e.target.value)}
             >
-              {meta.regions.map((r) => (
+              {(meta.regions ?? []).map((r) => (
                 <option key={r} value={r}>
                   {r}
                 </option>
@@ -226,7 +239,7 @@ export default function NicConfigBuilder(): JSX.Element {
                 value={state.instance}
                 onChange={(e) => set('instance', e.target.value)}
               >
-                {meta.instances.map((i) => (
+                {(meta.instances ?? []).map((i) => (
                   <option key={i} value={i}>
                     {i}
                   </option>
@@ -290,6 +303,7 @@ export default function NicConfigBuilder(): JSX.Element {
         <CodeBlock language="yaml" title="nebari-config.yaml">
           {yaml}
         </CodeBlock>
+      </div>
       </div>
     </div>
   );

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -9,8 +9,8 @@ import styles from './styles.module.css';
  * cloud provider, a DNS provider, and a handful of always-required fields, then
  * emits a minimal but valid-shaped config to copy. It is intentionally curated
  * rather than schema-driven: the full field set lives in the
- * [Configuration schema](/references/config-schema) reference, and the emitted
- * file is a starting point to refine and check with `nic validate`.
+ * [Configuration schema](/docs/references/config-schema) reference, and the
+ * emitted file is a starting point to refine and check with `nic validate`.
  */
 
 type ProviderKey = 'aws' | 'gcp' | 'azure' | 'hetzner';
@@ -19,14 +19,19 @@ type ProviderMeta = {
   label: string;
   // `stub: true` means the cloud is supported by NIC but not yet wired into this
   // builder; its tab shows a hand-off notice instead of a form. To enable a
-  // provider, drop `stub` and fill regionLabel/regions/instances with values
-  // confirmed against the schema (do not guess).
+  // provider, drop `stub` and fill the fields below with values confirmed
+  // against the schema (do not guess).
   stub?: boolean;
   regionLabel?: string;
   regions?: string[];
   instances?: string[];
-  // Whether the provider's schema carries `longhorn.dedicated_nodes` (Longhorn on
-  // a dedicated storage node group). Set only for providers where that is true.
+  // Node-group shape the provider's schema expects: 'aws' uses
+  // instance/min_nodes/max_nodes; 'hetzner' uses instance_type/count and needs a
+  // master group. kubernetes_version is required by every provider's schema.
+  nodeShape?: 'aws' | 'hetzner';
+  kubernetesVersion?: string;
+  // Whether the provider can express a dedicated Longhorn storage node group.
+  // Requires per-node-group labels/taints, which the Hetzner schema lacks.
   dedicatedStorage?: boolean;
 };
 
@@ -36,11 +41,20 @@ const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
     regionLabel: 'region',
     regions: ['us-west-2', 'us-east-1', 'eu-west-1', 'ap-southeast-2'],
     instances: ['m5.large', 'm5.xlarge', 'm5.2xlarge'],
+    nodeShape: 'aws',
+    kubernetesVersion: '1.34',
     dedicatedStorage: true,
   },
   gcp: { label: 'GCP', stub: true },
   azure: { label: 'Azure', stub: true },
-  hetzner: { label: 'Hetzner', stub: true },
+  hetzner: {
+    label: 'Hetzner',
+    regionLabel: 'location',
+    regions: ['fsn1', 'nbg1', 'hel1', 'ash', 'hil', 'sin'],
+    instances: ['cpx21', 'cpx31', 'cpx41', 'cpx51'],
+    nodeShape: 'hetzner',
+    kubernetesVersion: '1.32',
+  },
 };
 
 type BuilderState = {
@@ -48,7 +62,8 @@ type BuilderState = {
   projectName: string;
   domain: string;
   region: string;
-  certType: 'lets-encrypt' | 'self-signed';
+  kubernetesVersion: string;
+  certType: 'letsencrypt' | 'selfsigned';
   acmeEmail: string;
   nodeGroupName: string;
   instance: string;
@@ -64,7 +79,8 @@ const initialFor = (provider: ProviderKey): BuilderState => ({
   projectName: 'my-nebari',
   domain: 'nebari.example.com',
   region: PROVIDERS[provider].regions?.[0] ?? '',
-  certType: 'lets-encrypt',
+  kubernetesVersion: PROVIDERS[provider].kubernetesVersion ?? '',
+  certType: 'letsencrypt',
   acmeEmail: 'admin@example.com',
   nodeGroupName: 'general',
   instance: PROVIDERS[provider].instances?.[0] ?? '',
@@ -83,42 +99,60 @@ function buildYaml(s: BuilderState): string {
   lines.push(`domain: ${s.domain || 'nebari.example.com'}`);
 
   lines.push('certificate:');
-  if (s.certType === 'lets-encrypt') {
-    lines.push('  type: lets-encrypt');
+  if (s.certType === 'letsencrypt') {
+    lines.push('  type: letsencrypt');
     lines.push('  acme:');
     lines.push(`    email: ${s.acmeEmail || 'admin@example.com'}`);
   } else {
-    lines.push('  type: self-signed');
+    lines.push('  type: selfsigned');
   }
 
-  const dedicated = s.dedicatedStorage && meta.dedicatedStorage;
+  const k8s = s.kubernetesVersion || meta.kubernetesVersion || '';
+  const group = s.nodeGroupName || 'general';
 
   lines.push('cluster:');
   lines.push(`  ${s.provider}:`);
-  lines.push(`    ${meta.regionLabel ?? 'region'}: ${s.region}`);
-  lines.push('    node_groups:');
-  lines.push(`      ${s.nodeGroupName || 'general'}:`);
-  lines.push(`        instance: ${s.instance}`);
-  lines.push(`        min_nodes: ${s.minNodes}`);
-  lines.push(`        max_nodes: ${s.maxNodes}`);
-  if (dedicated) {
-    // A dedicated, tainted storage pool. The label is Longhorn's default
-    // node_selector; the taint keeps other workloads off. Longhorn confines
-    // replica disks to nodes carrying this label.
-    lines.push('      storage:');
+
+  if (meta.nodeShape === 'hetzner') {
+    // Hetzner (k3s) needs exactly one master node group; the builder adds it and
+    // treats the named group as workers. Node groups use instance_type/count.
+    const workers = group === 'master' ? 'workers' : group;
+    lines.push(`    location: ${s.region}`);
+    lines.push(`    kubernetes_version: "${k8s}"`);
+    lines.push('    node_groups:');
+    lines.push('      master:');
+    lines.push(`        instance_type: ${s.instance}`);
+    lines.push('        count: 1');
+    lines.push('        master: true');
+    lines.push(`      ${workers}:`);
+    lines.push(`        instance_type: ${s.instance}`);
+    lines.push(`        count: ${s.maxNodes}`);
+  } else {
+    const dedicated = s.dedicatedStorage && meta.dedicatedStorage;
+    lines.push(`    region: ${s.region}`);
+    lines.push(`    kubernetes_version: "${k8s}"`);
+    lines.push('    node_groups:');
+    lines.push(`      ${group}:`);
     lines.push(`        instance: ${s.instance}`);
-    lines.push('        min_nodes: 1');
-    lines.push('        max_nodes: 1');
-    lines.push('        labels:');
-    lines.push('          node.longhorn.io/storage: "true"');
-    lines.push('        taints:');
-    lines.push('          - key: node.longhorn.io/storage');
-    lines.push('            value: "true"');
-    lines.push('            effect: NO_SCHEDULE');
-  }
-  if (dedicated) {
-    lines.push('    longhorn:');
-    lines.push('      dedicated_nodes: true');
+    lines.push(`        min_nodes: ${s.minNodes}`);
+    lines.push(`        max_nodes: ${s.maxNodes}`);
+    if (dedicated) {
+      // A dedicated, tainted storage pool. The label is Longhorn's default
+      // node_selector; the taint keeps other workloads off. Longhorn confines
+      // replica disks to nodes carrying this label.
+      lines.push('      storage:');
+      lines.push(`        instance: ${s.instance}`);
+      lines.push('        min_nodes: 1');
+      lines.push('        max_nodes: 1');
+      lines.push('        labels:');
+      lines.push('          node.longhorn.io/storage: "true"');
+      lines.push('        taints:');
+      lines.push('          - key: node.longhorn.io/storage');
+      lines.push('            value: "true"');
+      lines.push('            effect: NO_SCHEDULE');
+      lines.push('    longhorn:');
+      lines.push('      dedicated_nodes: true');
+    }
   }
 
   if (s.useCloudflare) {
@@ -134,17 +168,20 @@ export default function NicConfigBuilder(): JSX.Element {
   const [state, setState] = useState<BuilderState>(() => initialFor('aws'));
   const meta = PROVIDERS[state.provider];
   const yaml = useMemo(() => buildYaml(state), [state]);
+  const isHetzner = meta.nodeShape === 'hetzner';
 
   const set = <K extends keyof BuilderState>(key: K, value: BuilderState[K]) =>
     setState((prev) => ({ ...prev, [key]: value }));
 
-  // Switching provider resets the region/instance to that provider's defaults.
+  // Switching provider resets the per-provider defaults (region, instance,
+  // kubernetes_version) to that provider's values.
   const changeProvider = (provider: ProviderKey) =>
     setState((prev) => ({
       ...prev,
       provider,
       region: PROVIDERS[provider].regions?.[0] ?? '',
       instance: PROVIDERS[provider].instances?.[0] ?? '',
+      kubernetesVersion: PROVIDERS[provider].kubernetesVersion ?? '',
     }));
 
   const providerSelector = (
@@ -187,170 +224,201 @@ export default function NicConfigBuilder(): JSX.Element {
     <div className={styles.wrapper}>
       {providerSelector}
       <div className={styles.builder}>
-      <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
-        <div className={styles.row}>
-          <label className={styles.field}>
-            <span className={styles.label}>project_name</span>
-            <input
-              className={styles.input}
-              value={state.projectName}
-              onChange={(e) => set('projectName', e.target.value)}
-            />
-          </label>
-          <label className={styles.field}>
-            <span className={styles.label}>domain</span>
-            <input
-              className={styles.input}
-              value={state.domain}
-              onChange={(e) => set('domain', e.target.value)}
-            />
-          </label>
-        </div>
-
-        <div className={styles.row}>
-          <label className={styles.field}>
-            <span className={styles.label}>
-              cluster.{state.provider}.{meta.regionLabel ?? 'region'}
-            </span>
-            <select
-              className={styles.input}
-              value={state.region}
-              onChange={(e) => set('region', e.target.value)}
-            >
-              {(meta.regions ?? []).map((r) => (
-                <option key={r} value={r}>
-                  {r}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className={styles.field}>
-            <span className={styles.label}>certificate.type</span>
-            <select
-              className={styles.input}
-              value={state.certType}
-              onChange={(e) => set('certType', e.target.value as BuilderState['certType'])}
-            >
-              <option value="lets-encrypt">lets-encrypt</option>
-              <option value="self-signed">self-signed</option>
-            </select>
-          </label>
-        </div>
-
-        {state.certType === 'lets-encrypt' && (
-          <label className={styles.field}>
-            <span className={styles.label}>certificate.acme.email</span>
-            <input
-              className={styles.input}
-              value={state.acmeEmail}
-              onChange={(e) => set('acmeEmail', e.target.value)}
-            />
-          </label>
-        )}
-
-        <fieldset className={styles.group}>
-          <legend className={styles.legend}>Default node group</legend>
+        <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
           <div className={styles.row}>
             <label className={styles.field}>
-              <span className={styles.label}>name</span>
+              <span className={styles.label}>project_name</span>
               <input
                 className={styles.input}
-                value={state.nodeGroupName}
-                onChange={(e) => set('nodeGroupName', e.target.value)}
+                value={state.projectName}
+                onChange={(e) => set('projectName', e.target.value)}
               />
             </label>
             <label className={styles.field}>
-              <span className={styles.label}>instance</span>
+              <span className={styles.label}>domain</span>
+              <input
+                className={styles.input}
+                value={state.domain}
+                onChange={(e) => set('domain', e.target.value)}
+              />
+            </label>
+          </div>
+
+          <div className={styles.row}>
+            <label className={styles.field}>
+              <span className={styles.label}>
+                cluster.{state.provider}.{meta.regionLabel ?? 'region'}
+              </span>
               <select
                 className={styles.input}
-                value={state.instance}
-                onChange={(e) => set('instance', e.target.value)}
+                value={state.region}
+                onChange={(e) => set('region', e.target.value)}
               >
-                {(meta.instances ?? []).map((i) => (
-                  <option key={i} value={i}>
-                    {i}
+                {(meta.regions ?? []).map((r) => (
+                  <option key={r} value={r}>
+                    {r}
                   </option>
                 ))}
               </select>
             </label>
+            <label className={styles.field}>
+              <span className={styles.label}>cluster.{state.provider}.kubernetes_version</span>
+              <input
+                className={styles.input}
+                value={state.kubernetesVersion}
+                onChange={(e) => set('kubernetesVersion', e.target.value)}
+              />
+            </label>
           </div>
+
           <div className={styles.row}>
             <label className={styles.field}>
-              <span className={styles.label}>min_nodes</span>
-              <input
+              <span className={styles.label}>certificate.type</span>
+              <select
                 className={styles.input}
-                type="number"
-                min={0}
-                value={state.minNodes}
-                onChange={(e) => set('minNodes', Number(e.target.value))}
-              />
+                value={state.certType}
+                onChange={(e) => set('certType', e.target.value as BuilderState['certType'])}
+              >
+                <option value="letsencrypt">letsencrypt</option>
+                <option value="selfsigned">selfsigned</option>
+              </select>
             </label>
-            <label className={styles.field}>
-              <span className={styles.label}>max_nodes</span>
-              <input
-                className={styles.input}
-                type="number"
-                min={1}
-                value={state.maxNodes}
-                onChange={(e) => set('maxNodes', Number(e.target.value))}
-              />
-            </label>
+            {state.certType === 'letsencrypt' && (
+              <label className={styles.field}>
+                <span className={styles.label}>certificate.acme.email</span>
+                <input
+                  className={styles.input}
+                  value={state.acmeEmail}
+                  onChange={(e) => set('acmeEmail', e.target.value)}
+                />
+              </label>
+            )}
           </div>
-        </fieldset>
 
-        {meta.dedicatedStorage && (
           <fieldset className={styles.group}>
-            <legend className={styles.legend}>Longhorn storage</legend>
+            <legend className={styles.legend}>Node group</legend>
+            <div className={styles.row}>
+              <label className={styles.field}>
+                <span className={styles.label}>name</span>
+                <input
+                  className={styles.input}
+                  value={state.nodeGroupName}
+                  onChange={(e) => set('nodeGroupName', e.target.value)}
+                />
+              </label>
+              <label className={styles.field}>
+                <span className={styles.label}>{isHetzner ? 'instance_type' : 'instance'}</span>
+                <select
+                  className={styles.input}
+                  value={state.instance}
+                  onChange={(e) => set('instance', e.target.value)}
+                >
+                  {(meta.instances ?? []).map((i) => (
+                    <option key={i} value={i}>
+                      {i}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {isHetzner ? (
+              <div className={styles.row}>
+                <label className={styles.field}>
+                  <span className={styles.label}>count</span>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min={1}
+                    value={state.maxNodes}
+                    onChange={(e) => set('maxNodes', Number(e.target.value))}
+                  />
+                </label>
+              </div>
+            ) : (
+              <div className={styles.row}>
+                <label className={styles.field}>
+                  <span className={styles.label}>min_nodes</span>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min={0}
+                    value={state.minNodes}
+                    onChange={(e) => set('minNodes', Number(e.target.value))}
+                  />
+                </label>
+                <label className={styles.field}>
+                  <span className={styles.label}>max_nodes</span>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min={1}
+                    value={state.maxNodes}
+                    onChange={(e) => set('maxNodes', Number(e.target.value))}
+                  />
+                </label>
+              </div>
+            )}
+            {isHetzner && (
+              <p className={styles.hint}>
+                Hetzner (k3s) needs a master node group; the builder adds one automatically
+                alongside this worker group.
+              </p>
+            )}
+          </fieldset>
+
+          {meta.dedicatedStorage && (
+            <fieldset className={styles.group}>
+              <legend className={styles.legend}>Longhorn storage</legend>
+              <label className={styles.checkbox}>
+                <input
+                  type="checkbox"
+                  checked={state.dedicatedStorage}
+                  onChange={(e) => set('dedicatedStorage', e.target.checked)}
+                />
+                <span>Dedicated storage node group</span>
+              </label>
+              <p className={styles.hint}>
+                Adds a tainted <code>storage</code> node group and sets{' '}
+                <code>longhorn.dedicated_nodes</code>, confining Longhorn replicas to it. On
+                an existing cluster this is a manual migration; see the{' '}
+                <Link to="/docs/references/config-schema">configuration schema</Link>.
+              </p>
+            </fieldset>
+          )}
+
+          <fieldset className={styles.group}>
+            <legend className={styles.legend}>DNS</legend>
             <label className={styles.checkbox}>
               <input
                 type="checkbox"
-                checked={state.dedicatedStorage}
-                onChange={(e) => set('dedicatedStorage', e.target.checked)}
+                checked={state.useCloudflare}
+                onChange={(e) => set('useCloudflare', e.target.checked)}
               />
-              <span>Dedicated storage node group</span>
+              <span>Manage DNS with Cloudflare</span>
             </label>
-            <p className={styles.hint}>
-              Adds a tainted <code>storage</code> node group and sets{' '}
-              <code>longhorn.dedicated_nodes</code>, confining Longhorn replicas to it. On an
-              existing cluster this is a manual migration; see the{' '}
-              <Link to="/docs/references/config-schema">configuration schema</Link>.
-            </p>
+            {state.useCloudflare && (
+              <label className={styles.field}>
+                <span className={styles.label}>dns.cloudflare.zone_id</span>
+                <input
+                  className={styles.input}
+                  placeholder="<your-cloudflare-zone-id>"
+                  value={state.zoneId}
+                  onChange={(e) => set('zoneId', e.target.value)}
+                />
+              </label>
+            )}
           </fieldset>
-        )}
+        </form>
 
-        <fieldset className={styles.group}>
-          <legend className={styles.legend}>DNS</legend>
-          <label className={styles.checkbox}>
-            <input
-              type="checkbox"
-              checked={state.useCloudflare}
-              onChange={(e) => set('useCloudflare', e.target.checked)}
-            />
-            <span>Manage DNS with Cloudflare</span>
-          </label>
-          {state.useCloudflare && (
-            <label className={styles.field}>
-              <span className={styles.label}>dns.cloudflare.zone_id</span>
-              <input
-                className={styles.input}
-                placeholder="<your-cloudflare-zone-id>"
-                value={state.zoneId}
-                onChange={(e) => set('zoneId', e.target.value)}
-              />
-            </label>
-          )}
-        </fieldset>
-      </form>
-
-      <div className={styles.output}>
-        <div className={styles.outputHead}>
-          <span className={styles.outputTitle}>nebari-config.yaml</span>
-          <span className={styles.starterBadge}>starter</span>
+        <div className={styles.output}>
+          <div className={styles.outputHead}>
+            <span className={styles.outputTitle}>nebari-config.yaml</span>
+            <span className={styles.starterBadge}>starter</span>
+          </div>
+          <CodeBlock language="yaml" title="nebari-config.yaml">
+            {yaml}
+          </CodeBlock>
         </div>
-        <CodeBlock language="yaml" title="nebari-config.yaml">
-          {yaml}
-        </CodeBlock>
-      </div>
       </div>
     </div>
   );

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -25,6 +25,9 @@ type ProviderMeta = {
   regionLabel?: string;
   regions?: string[];
   instances?: string[];
+  // Whether the provider's schema carries `longhorn.dedicated_nodes` (Longhorn on
+  // a dedicated storage node group). Set only for providers where that is true.
+  dedicatedStorage?: boolean;
 };
 
 const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
@@ -33,6 +36,7 @@ const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
     regionLabel: 'region',
     regions: ['us-west-2', 'us-east-1', 'eu-west-1', 'ap-southeast-2'],
     instances: ['m5.large', 'm5.xlarge', 'm5.2xlarge'],
+    dedicatedStorage: true,
   },
   gcp: { label: 'GCP', stub: true },
   azure: { label: 'Azure', stub: true },
@@ -50,6 +54,7 @@ type BuilderState = {
   instance: string;
   minNodes: number;
   maxNodes: number;
+  dedicatedStorage: boolean;
   useCloudflare: boolean;
   zoneId: string;
 };
@@ -65,6 +70,7 @@ const initialFor = (provider: ProviderKey): BuilderState => ({
   instance: PROVIDERS[provider].instances?.[0] ?? '',
   minNodes: 1,
   maxNodes: 5,
+  dedicatedStorage: false,
   useCloudflare: true,
   zoneId: '',
 });
@@ -85,14 +91,35 @@ function buildYaml(s: BuilderState): string {
     lines.push('  type: self-signed');
   }
 
+  const dedicated = s.dedicatedStorage && meta.dedicatedStorage;
+
   lines.push('cluster:');
   lines.push(`  ${s.provider}:`);
-  lines.push(`    ${meta.regionLabel}: ${s.region}`);
+  lines.push(`    ${meta.regionLabel ?? 'region'}: ${s.region}`);
   lines.push('    node_groups:');
   lines.push(`      ${s.nodeGroupName || 'general'}:`);
   lines.push(`        instance: ${s.instance}`);
   lines.push(`        min_nodes: ${s.minNodes}`);
   lines.push(`        max_nodes: ${s.maxNodes}`);
+  if (dedicated) {
+    // A dedicated, tainted storage pool. The label is Longhorn's default
+    // node_selector; the taint keeps other workloads off. Longhorn confines
+    // replica disks to nodes carrying this label.
+    lines.push('      storage:');
+    lines.push(`        instance: ${s.instance}`);
+    lines.push('        min_nodes: 1');
+    lines.push('        max_nodes: 1');
+    lines.push('        labels:');
+    lines.push('          node.longhorn.io/storage: "true"');
+    lines.push('        taints:');
+    lines.push('          - key: node.longhorn.io/storage');
+    lines.push('            value: "true"');
+    lines.push('            effect: NO_SCHEDULE');
+  }
+  if (dedicated) {
+    lines.push('    longhorn:');
+    lines.push('      dedicated_nodes: true');
+  }
 
   if (s.useCloudflare) {
     lines.push('dns:');
@@ -270,6 +297,26 @@ export default function NicConfigBuilder(): JSX.Element {
             </label>
           </div>
         </fieldset>
+
+        {meta.dedicatedStorage && (
+          <fieldset className={styles.group}>
+            <legend className={styles.legend}>Longhorn storage</legend>
+            <label className={styles.checkbox}>
+              <input
+                type="checkbox"
+                checked={state.dedicatedStorage}
+                onChange={(e) => set('dedicatedStorage', e.target.checked)}
+              />
+              <span>Dedicated storage node group</span>
+            </label>
+            <p className={styles.hint}>
+              Adds a tainted <code>storage</code> node group and sets{' '}
+              <code>longhorn.dedicated_nodes</code>, confining Longhorn replicas to it. On an
+              existing cluster this is a manual migration; see the{' '}
+              <Link to="/docs/references/config-schema">configuration schema</Link>.
+            </p>
+          </fieldset>
+        )}
 
         <fieldset className={styles.group}>
           <legend className={styles.legend}>DNS</legend>

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -65,6 +65,11 @@ type BuilderState = {
   kubernetesVersion: string;
   certType: 'letsencrypt' | 'selfsigned';
   acmeEmail: string;
+  gitUrl: string;
+  gitBranch: string;
+  gitPath: string;
+  gitAuthMethod: 'token' | 'ssh';
+  gitEnvVar: string;
   nodeGroupName: string;
   instance: string;
   minNodes: number;
@@ -82,6 +87,11 @@ const initialFor = (provider: ProviderKey): BuilderState => ({
   kubernetesVersion: PROVIDERS[provider].kubernetesVersion ?? '',
   certType: 'letsencrypt',
   acmeEmail: 'admin@example.com',
+  gitUrl: 'https://github.com/my-org/my-nebari-config.git',
+  gitBranch: 'main',
+  gitPath: 'clusters/my-nebari',
+  gitAuthMethod: 'token',
+  gitEnvVar: 'GIT_TOKEN',
   nodeGroupName: 'general',
   instance: PROVIDERS[provider].instances?.[0] ?? '',
   minNodes: 1,
@@ -106,6 +116,17 @@ function buildYaml(s: BuilderState): string {
   } else {
     lines.push('  type: selfsigned');
   }
+
+  lines.push('git_repository:');
+  lines.push(`  url: ${s.gitUrl || '<repo-url>'}`);
+  lines.push(`  branch: ${s.gitBranch || 'main'}`);
+  lines.push(`  path: ${s.gitPath || '<path>'}`);
+  lines.push('  auth:');
+  lines.push(
+    `    ${s.gitAuthMethod === 'ssh' ? 'ssh_key_env' : 'token_env'}: ${
+      s.gitEnvVar || (s.gitAuthMethod === 'ssh' ? 'GIT_SSH_PRIVATE_KEY' : 'GIT_TOKEN')
+    }`,
+  );
 
   const k8s = s.kubernetesVersion || meta.kubernetesVersion || '';
   const group = s.nodeGroupName || 'general';
@@ -319,6 +340,66 @@ export default function NicConfigBuilder(): JSX.Element {
                   />
                 </LabeledField>
               )}
+            </div>
+          </Section>
+
+          <Section label="Git repository">
+            <p className={styles.sectionNote}>
+              NIC pushes rendered manifests to this GitOps repo; foundational services sync
+              from it. Credentials are read from an environment variable at deploy time.
+            </p>
+            <LabeledField label="Repository URL" schemaKey="git_repository.url" required>
+              <input
+                className={styles.input}
+                value={state.gitUrl}
+                onChange={(e) => set('gitUrl', e.target.value)}
+              />
+            </LabeledField>
+            <div className={styles.grid2} style={{ marginTop: '16px' }}>
+              <LabeledField label="Branch" schemaKey="git_repository.branch" required>
+                <input
+                  className={styles.input}
+                  value={state.gitBranch}
+                  onChange={(e) => set('gitBranch', e.target.value)}
+                />
+              </LabeledField>
+              <LabeledField label="Path" schemaKey="git_repository.path" required>
+                <input
+                  className={styles.input}
+                  value={state.gitPath}
+                  onChange={(e) => set('gitPath', e.target.value)}
+                />
+              </LabeledField>
+              <LabeledField label="Auth method" schemaKey="git_repository.auth">
+                <select
+                  className={styles.input}
+                  value={state.gitAuthMethod}
+                  onChange={(e) => {
+                    const m = e.target.value as BuilderState['gitAuthMethod'];
+                    setState((prev) => ({
+                      ...prev,
+                      gitAuthMethod: m,
+                      gitEnvVar: m === 'ssh' ? 'GIT_SSH_PRIVATE_KEY' : 'GIT_TOKEN',
+                    }));
+                  }}
+                >
+                  <option value="token">token (HTTPS)</option>
+                  <option value="ssh">ssh key</option>
+                </select>
+              </LabeledField>
+              <LabeledField
+                label={state.gitAuthMethod === 'ssh' ? 'SSH key env var' : 'Token env var'}
+                schemaKey={`git_repository.auth.${
+                  state.gitAuthMethod === 'ssh' ? 'ssh_key_env' : 'token_env'
+                }`}
+                required
+              >
+                <input
+                  className={styles.input}
+                  value={state.gitEnvVar}
+                  onChange={(e) => set('gitEnvVar', e.target.value)}
+                />
+              </LabeledField>
             </div>
           </Section>
 

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -1,0 +1,296 @@
+import CodeBlock from '@theme/CodeBlock';
+import React, { useMemo, useState } from 'react';
+
+import styles from './styles.module.css';
+
+/**
+ * NicConfigBuilder is a guided starter for `nebari-config.yaml`. It asks for a
+ * cloud provider, a DNS provider, and a handful of always-required fields, then
+ * emits a minimal but valid-shaped config to copy. It is intentionally curated
+ * rather than schema-driven: the full field set lives in the
+ * [Configuration schema](/references/config-schema) reference, and the emitted
+ * file is a starting point to refine and check with `nic validate`.
+ */
+
+type ProviderKey = 'aws' | 'gcp' | 'azure' | 'hetzner';
+
+type ProviderMeta = {
+  label: string;
+  regionLabel: string;
+  regions: string[];
+  instances: string[];
+};
+
+const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
+  aws: {
+    label: 'AWS',
+    regionLabel: 'region',
+    regions: ['us-west-2', 'us-east-1', 'eu-west-1', 'ap-southeast-2'],
+    instances: ['m5.large', 'm5.xlarge', 'm5.2xlarge'],
+  },
+  gcp: {
+    label: 'GCP',
+    regionLabel: 'region',
+    regions: ['us-central1', 'us-east1', 'europe-west1'],
+    instances: ['e2-standard-4', 'n2-standard-4', 'n2-standard-8'],
+  },
+  azure: {
+    label: 'Azure',
+    regionLabel: 'region',
+    regions: ['eastus', 'westeurope', 'australiaeast'],
+    instances: ['Standard_D4s_v5', 'Standard_D8s_v5'],
+  },
+  hetzner: {
+    label: 'Hetzner',
+    regionLabel: 'location',
+    regions: ['nbg1', 'fsn1', 'hel1'],
+    instances: ['cpx31', 'cpx41', 'cpx51'],
+  },
+};
+
+type BuilderState = {
+  provider: ProviderKey;
+  projectName: string;
+  domain: string;
+  region: string;
+  certType: 'lets-encrypt' | 'self-signed';
+  acmeEmail: string;
+  nodeGroupName: string;
+  instance: string;
+  minNodes: number;
+  maxNodes: number;
+  useCloudflare: boolean;
+  zoneId: string;
+};
+
+const initialFor = (provider: ProviderKey): BuilderState => ({
+  provider,
+  projectName: 'my-nebari',
+  domain: 'nebari.example.com',
+  region: PROVIDERS[provider].regions[0],
+  certType: 'lets-encrypt',
+  acmeEmail: 'admin@example.com',
+  nodeGroupName: 'general',
+  instance: PROVIDERS[provider].instances[0],
+  minNodes: 1,
+  maxNodes: 5,
+  useCloudflare: true,
+  zoneId: '',
+});
+
+function buildYaml(s: BuilderState): string {
+  const meta = PROVIDERS[s.provider];
+  const lines: string[] = [];
+
+  lines.push(`project_name: ${s.projectName || 'my-nebari'}`);
+  lines.push(`domain: ${s.domain || 'nebari.example.com'}`);
+
+  lines.push('certificate:');
+  if (s.certType === 'lets-encrypt') {
+    lines.push('  type: lets-encrypt');
+    lines.push('  acme:');
+    lines.push(`    email: ${s.acmeEmail || 'admin@example.com'}`);
+  } else {
+    lines.push('  type: self-signed');
+  }
+
+  lines.push('cluster:');
+  lines.push(`  ${s.provider}:`);
+  lines.push(`    ${meta.regionLabel}: ${s.region}`);
+  lines.push('    node_groups:');
+  lines.push(`      ${s.nodeGroupName || 'general'}:`);
+  lines.push(`        instance: ${s.instance}`);
+  lines.push(`        min_nodes: ${s.minNodes}`);
+  lines.push(`        max_nodes: ${s.maxNodes}`);
+
+  if (s.useCloudflare) {
+    lines.push('dns:');
+    lines.push('  cloudflare:');
+    lines.push(`    zone_id: ${s.zoneId || '<your-cloudflare-zone-id>'}`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export default function NicConfigBuilder(): JSX.Element {
+  const [state, setState] = useState<BuilderState>(() => initialFor('aws'));
+  const meta = PROVIDERS[state.provider];
+  const yaml = useMemo(() => buildYaml(state), [state]);
+
+  const set = <K extends keyof BuilderState>(key: K, value: BuilderState[K]) =>
+    setState((prev) => ({ ...prev, [key]: value }));
+
+  // Switching provider resets the region/instance to that provider's defaults.
+  const changeProvider = (provider: ProviderKey) =>
+    setState((prev) => ({
+      ...prev,
+      provider,
+      region: PROVIDERS[provider].regions[0],
+      instance: PROVIDERS[provider].instances[0],
+    }));
+
+  return (
+    <div className={styles.builder}>
+      <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+        <fieldset className={styles.group}>
+          <legend className={styles.legend}>Cloud provider</legend>
+          <div className={styles.pills}>
+            {(Object.keys(PROVIDERS) as ProviderKey[]).map((key) => (
+              <button
+                key={key}
+                type="button"
+                className={`${styles.pill} ${state.provider === key ? styles.pillActive : ''}`}
+                onClick={() => changeProvider(key)}
+              >
+                {PROVIDERS[key].label}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <span className={styles.label}>project_name</span>
+            <input
+              className={styles.input}
+              value={state.projectName}
+              onChange={(e) => set('projectName', e.target.value)}
+            />
+          </label>
+          <label className={styles.field}>
+            <span className={styles.label}>domain</span>
+            <input
+              className={styles.input}
+              value={state.domain}
+              onChange={(e) => set('domain', e.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <span className={styles.label}>
+              cluster.{state.provider}.{meta.regionLabel}
+            </span>
+            <select
+              className={styles.input}
+              value={state.region}
+              onChange={(e) => set('region', e.target.value)}
+            >
+              {meta.regions.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.field}>
+            <span className={styles.label}>certificate.type</span>
+            <select
+              className={styles.input}
+              value={state.certType}
+              onChange={(e) => set('certType', e.target.value as BuilderState['certType'])}
+            >
+              <option value="lets-encrypt">lets-encrypt</option>
+              <option value="self-signed">self-signed</option>
+            </select>
+          </label>
+        </div>
+
+        {state.certType === 'lets-encrypt' && (
+          <label className={styles.field}>
+            <span className={styles.label}>certificate.acme.email</span>
+            <input
+              className={styles.input}
+              value={state.acmeEmail}
+              onChange={(e) => set('acmeEmail', e.target.value)}
+            />
+          </label>
+        )}
+
+        <fieldset className={styles.group}>
+          <legend className={styles.legend}>Default node group</legend>
+          <div className={styles.row}>
+            <label className={styles.field}>
+              <span className={styles.label}>name</span>
+              <input
+                className={styles.input}
+                value={state.nodeGroupName}
+                onChange={(e) => set('nodeGroupName', e.target.value)}
+              />
+            </label>
+            <label className={styles.field}>
+              <span className={styles.label}>instance</span>
+              <select
+                className={styles.input}
+                value={state.instance}
+                onChange={(e) => set('instance', e.target.value)}
+              >
+                {meta.instances.map((i) => (
+                  <option key={i} value={i}>
+                    {i}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <div className={styles.row}>
+            <label className={styles.field}>
+              <span className={styles.label}>min_nodes</span>
+              <input
+                className={styles.input}
+                type="number"
+                min={0}
+                value={state.minNodes}
+                onChange={(e) => set('minNodes', Number(e.target.value))}
+              />
+            </label>
+            <label className={styles.field}>
+              <span className={styles.label}>max_nodes</span>
+              <input
+                className={styles.input}
+                type="number"
+                min={1}
+                value={state.maxNodes}
+                onChange={(e) => set('maxNodes', Number(e.target.value))}
+              />
+            </label>
+          </div>
+        </fieldset>
+
+        <fieldset className={styles.group}>
+          <legend className={styles.legend}>DNS</legend>
+          <label className={styles.checkbox}>
+            <input
+              type="checkbox"
+              checked={state.useCloudflare}
+              onChange={(e) => set('useCloudflare', e.target.checked)}
+            />
+            <span>Manage DNS with Cloudflare</span>
+          </label>
+          {state.useCloudflare && (
+            <label className={styles.field}>
+              <span className={styles.label}>dns.cloudflare.zone_id</span>
+              <input
+                className={styles.input}
+                placeholder="<your-cloudflare-zone-id>"
+                value={state.zoneId}
+                onChange={(e) => set('zoneId', e.target.value)}
+              />
+            </label>
+          )}
+        </fieldset>
+      </form>
+
+      <div className={styles.output}>
+        <div className={styles.outputHead}>
+          <span className={styles.outputTitle}>nebari-config.yaml</span>
+          <span className={styles.starterBadge}>starter</span>
+        </div>
+        <CodeBlock language="yaml" title="nebari-config.yaml">
+          {yaml}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -695,15 +695,10 @@ export default function NicConfigBuilder(): JSX.Element {
               >
                 <input
                   className={styles.input}
-                  list={`instances-${derived.name}`}
+                  placeholder={derived.instances[0] ?? (isHetzner ? 'e.g. cpx31' : 'e.g. m5.xlarge')}
                   value={state.instance}
                   onChange={(e) => set('instance', e.target.value)}
                 />
-                <datalist id={`instances-${derived.name}`}>
-                  {derived.instances.map((i) => (
-                    <option key={i} value={i} />
-                  ))}
-                </datalist>
               </LabeledField>
               {isHetzner ? (
                 <LabeledField label="Count" schemaKey="count" required>
@@ -820,7 +815,7 @@ export default function NicConfigBuilder(): JSX.Element {
               </button>
               <button
                 type="button"
-                className={styles.btn}
+                className={styles.iconBtn}
                 onClick={() => setModalOpen(false)}
                 aria-label="Close"
               >

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -164,6 +164,44 @@ function buildYaml(s: BuilderState): string {
   return `${lines.join('\n')}\n`;
 }
 
+// A labelled control: human label + the schema key it maps to, above the input.
+function LabeledField({
+  label,
+  schemaKey,
+  required,
+  children,
+}: {
+  label: string;
+  schemaKey: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.field}>
+      <div className={styles.fieldLabelRow}>
+        <label className={styles.fieldLabel}>
+          {label}
+          {required && <span className={styles.req}>*</span>}
+        </label>
+        <span className={styles.fieldKey}>{schemaKey}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className={styles.sectionHead}>
+        <span className={styles.sectionLabel}>{label}</span>
+        <span className={styles.rule} />
+      </div>
+      {children}
+    </div>
+  );
+}
+
 export default function NicConfigBuilder(): JSX.Element {
   const [state, setState] = useState<BuilderState>(() => initialFor('aws'));
   const meta = PROVIDERS[state.provider];
@@ -184,22 +222,41 @@ export default function NicConfigBuilder(): JSX.Element {
       kubernetesVersion: PROVIDERS[provider].kubernetesVersion ?? '',
     }));
 
-  const providerSelector = (
-    <fieldset className={styles.group}>
-      <legend className={styles.legend}>Cloud provider</legend>
-      <div className={styles.pills}>
-        {(Object.keys(PROVIDERS) as ProviderKey[]).map((key) => (
-          <button
-            key={key}
-            type="button"
-            className={`${styles.pill} ${state.provider === key ? styles.pillActive : ''}`}
-            onClick={() => changeProvider(key)}
-          >
-            {PROVIDERS[key].label}
-          </button>
-        ))}
+  const download = () => {
+    const blob = new Blob([yaml], { type: 'text/yaml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nebari-config.yaml';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
+  };
+
+  const providerCards = (
+    <div>
+      <div className={styles.providerLabel}>Cloud provider</div>
+      <div className={styles.providerCards}>
+        {(Object.keys(PROVIDERS) as ProviderKey[]).map((key) => {
+          const p = PROVIDERS[key];
+          const active = state.provider === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              className={`${styles.providerCard} ${active ? styles.providerCardActive : ''} ${
+                p.stub ? styles.providerCardStub : ''
+              }`}
+              onClick={() => changeProvider(key)}
+            >
+              <span className={styles.providerName}>{p.label}</span>
+              <span className={styles.providerStatus}>{p.stub ? 'Not wired yet' : 'Ready'}</span>
+            </button>
+          );
+        })}
       </div>
-    </fieldset>
+    </div>
   );
 
   // A supported cloud that this builder does not yet cover: hand the reader off
@@ -207,14 +264,16 @@ export default function NicConfigBuilder(): JSX.Element {
   if (meta.stub) {
     return (
       <div className={styles.wrapper}>
-        {providerSelector}
+        {providerCards}
         <div className={styles.stub}>
+          <div className={styles.stubTitle}>Not wired into this builder yet</div>
           <p>
-            Nebari supports {meta.label}, but it is not yet wired into this UI. Write the
-            YAML by hand using the{' '}
-            <Link to="/docs/references/config-schema">configuration schema</Link> for the
-            full set of fields.
+            NIC supports {meta.label}, but its regions and machine types are not confirmed
+            against the schema, so the builder will not guess them.
           </p>
+          <Link className={styles.stubLink} to="/docs/references/config-schema">
+            Write it from the schema →
+          </Link>
         </div>
       </div>
     );
@@ -222,92 +281,94 @@ export default function NicConfigBuilder(): JSX.Element {
 
   return (
     <div className={styles.wrapper}>
-      {providerSelector}
+      {providerCards}
       <div className={styles.builder}>
         <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
-          <div className={styles.row}>
-            <label className={styles.field}>
-              <span className={styles.label}>project_name</span>
-              <input
-                className={styles.input}
-                value={state.projectName}
-                onChange={(e) => set('projectName', e.target.value)}
-              />
-            </label>
-            <label className={styles.field}>
-              <span className={styles.label}>domain</span>
-              <input
-                className={styles.input}
-                value={state.domain}
-                onChange={(e) => set('domain', e.target.value)}
-              />
-            </label>
-          </div>
-
-          <div className={styles.row}>
-            <label className={styles.field}>
-              <span className={styles.label}>
-                cluster.{state.provider}.{meta.regionLabel ?? 'region'}
-              </span>
-              <select
-                className={styles.input}
-                value={state.region}
-                onChange={(e) => set('region', e.target.value)}
-              >
-                {(meta.regions ?? []).map((r) => (
-                  <option key={r} value={r}>
-                    {r}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className={styles.field}>
-              <span className={styles.label}>cluster.{state.provider}.kubernetes_version</span>
-              <input
-                className={styles.input}
-                value={state.kubernetesVersion}
-                onChange={(e) => set('kubernetesVersion', e.target.value)}
-              />
-            </label>
-          </div>
-
-          <div className={styles.row}>
-            <label className={styles.field}>
-              <span className={styles.label}>certificate.type</span>
-              <select
-                className={styles.input}
-                value={state.certType}
-                onChange={(e) => set('certType', e.target.value as BuilderState['certType'])}
-              >
-                <option value="letsencrypt">letsencrypt</option>
-                <option value="selfsigned">selfsigned</option>
-              </select>
-            </label>
-            {state.certType === 'letsencrypt' && (
-              <label className={styles.field}>
-                <span className={styles.label}>certificate.acme.email</span>
+          <Section label="Deployment">
+            <div className={styles.grid2}>
+              <LabeledField label="Project name" schemaKey="project_name" required>
                 <input
                   className={styles.input}
-                  value={state.acmeEmail}
-                  onChange={(e) => set('acmeEmail', e.target.value)}
+                  value={state.projectName}
+                  onChange={(e) => set('projectName', e.target.value)}
                 />
-              </label>
-            )}
-          </div>
+              </LabeledField>
+              <LabeledField label="Domain" schemaKey="domain">
+                <input
+                  className={styles.input}
+                  value={state.domain}
+                  onChange={(e) => set('domain', e.target.value)}
+                />
+              </LabeledField>
+              <LabeledField label="Certificate" schemaKey="certificate.type">
+                <select
+                  className={styles.input}
+                  value={state.certType}
+                  onChange={(e) => set('certType', e.target.value as BuilderState['certType'])}
+                >
+                  <option value="letsencrypt">letsencrypt</option>
+                  <option value="selfsigned">selfsigned</option>
+                </select>
+              </LabeledField>
+              {state.certType === 'letsencrypt' && (
+                <LabeledField label="ACME email" schemaKey="certificate.acme.email">
+                  <input
+                    className={styles.input}
+                    value={state.acmeEmail}
+                    onChange={(e) => set('acmeEmail', e.target.value)}
+                  />
+                </LabeledField>
+              )}
+            </div>
+          </Section>
 
-          <fieldset className={styles.group}>
-            <legend className={styles.legend}>Node group</legend>
-            <div className={styles.row}>
-              <label className={styles.field}>
-                <span className={styles.label}>name</span>
+          <Section label="Cluster">
+            <div className={styles.grid2}>
+              <LabeledField
+                label={isHetzner ? 'Location' : 'Region'}
+                schemaKey={`cluster.${state.provider}.${meta.regionLabel ?? 'region'}`}
+                required
+              >
+                <select
+                  className={styles.input}
+                  value={state.region}
+                  onChange={(e) => set('region', e.target.value)}
+                >
+                  {(meta.regions ?? []).map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+              </LabeledField>
+              <LabeledField label="Kubernetes version" schemaKey="kubernetes_version" required>
+                <input
+                  className={styles.input}
+                  value={state.kubernetesVersion}
+                  onChange={(e) => set('kubernetesVersion', e.target.value)}
+                />
+              </LabeledField>
+            </div>
+          </Section>
+
+          <Section label="Node group">
+            <p className={styles.sectionNote}>
+              The pool your workloads land on. Add more later in the config file.
+              {isHetzner && ' Hetzner (k3s) also needs a master group, which the builder adds automatically.'}
+            </p>
+            <div className={isHetzner ? styles.gridNodeHetzner : styles.gridNode}>
+              <LabeledField label="Name" schemaKey="key">
                 <input
                   className={styles.input}
                   value={state.nodeGroupName}
                   onChange={(e) => set('nodeGroupName', e.target.value)}
                 />
-              </label>
-              <label className={styles.field}>
-                <span className={styles.label}>{isHetzner ? 'instance_type' : 'instance'}</span>
+              </LabeledField>
+              <LabeledField
+                label="Instance"
+                schemaKey={isHetzner ? 'instance_type' : 'instance'}
+                required
+              >
                 <select
                   className={styles.input}
                   value={state.instance}
@@ -319,105 +380,99 @@ export default function NicConfigBuilder(): JSX.Element {
                     </option>
                   ))}
                 </select>
-              </label>
+              </LabeledField>
+              {isHetzner ? (
+                <LabeledField label="Count" schemaKey="count" required>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min={1}
+                    value={state.maxNodes}
+                    onChange={(e) => set('maxNodes', Number(e.target.value))}
+                  />
+                </LabeledField>
+              ) : (
+                <>
+                  <LabeledField label="Min" schemaKey="min_nodes">
+                    <input
+                      className={styles.input}
+                      type="number"
+                      min={0}
+                      value={state.minNodes}
+                      onChange={(e) => set('minNodes', Number(e.target.value))}
+                    />
+                  </LabeledField>
+                  <LabeledField label="Max" schemaKey="max_nodes">
+                    <input
+                      className={styles.input}
+                      type="number"
+                      min={1}
+                      value={state.maxNodes}
+                      onChange={(e) => set('maxNodes', Number(e.target.value))}
+                    />
+                  </LabeledField>
+                </>
+              )}
             </div>
-            {isHetzner ? (
-              <div className={styles.row}>
-                <label className={styles.field}>
-                  <span className={styles.label}>count</span>
-                  <input
-                    className={styles.input}
-                    type="number"
-                    min={1}
-                    value={state.maxNodes}
-                    onChange={(e) => set('maxNodes', Number(e.target.value))}
-                  />
-                </label>
-              </div>
-            ) : (
-              <div className={styles.row}>
-                <label className={styles.field}>
-                  <span className={styles.label}>min_nodes</span>
-                  <input
-                    className={styles.input}
-                    type="number"
-                    min={0}
-                    value={state.minNodes}
-                    onChange={(e) => set('minNodes', Number(e.target.value))}
-                  />
-                </label>
-                <label className={styles.field}>
-                  <span className={styles.label}>max_nodes</span>
-                  <input
-                    className={styles.input}
-                    type="number"
-                    min={1}
-                    value={state.maxNodes}
-                    onChange={(e) => set('maxNodes', Number(e.target.value))}
-                  />
-                </label>
-              </div>
-            )}
-            {isHetzner && (
-              <p className={styles.hint}>
-                Hetzner (k3s) needs a master node group; the builder adds one automatically
-                alongside this worker group.
-              </p>
-            )}
-          </fieldset>
+          </Section>
 
-          {meta.dedicatedStorage && (
-            <fieldset className={styles.group}>
-              <legend className={styles.legend}>Longhorn storage</legend>
-              <label className={styles.checkbox}>
+          <Section label="Options">
+            <div className={styles.options}>
+              {meta.dedicatedStorage && (
+                <label className={styles.option}>
+                  <input
+                    type="checkbox"
+                    checked={state.dedicatedStorage}
+                    onChange={(e) => set('dedicatedStorage', e.target.checked)}
+                  />
+                  <span>
+                    <span className={styles.optionTitle}>Dedicated storage nodes for Longhorn</span>
+                    <span className={styles.optionDesc}>
+                      Adds a tainted <code>storage</code> node group so replica disks stay off
+                      your workload nodes. Changing this on a live cluster is a manual migration.
+                    </span>
+                  </span>
+                </label>
+              )}
+              <label className={styles.option}>
                 <input
                   type="checkbox"
-                  checked={state.dedicatedStorage}
-                  onChange={(e) => set('dedicatedStorage', e.target.checked)}
+                  checked={state.useCloudflare}
+                  onChange={(e) => set('useCloudflare', e.target.checked)}
                 />
-                <span>Dedicated storage node group</span>
+                <span>
+                  <span className={styles.optionTitle}>Let Nebari manage DNS with Cloudflare</span>
+                  <span className={styles.optionDesc}>
+                    Your API token comes from the environment at deploy time; only the zone id
+                    goes in this file.
+                  </span>
+                </span>
               </label>
-              <p className={styles.hint}>
-                Adds a tainted <code>storage</code> node group and sets{' '}
-                <code>longhorn.dedicated_nodes</code>, confining Longhorn replicas to it. On
-                an existing cluster this is a manual migration; see the{' '}
-                <Link to="/docs/references/config-schema">configuration schema</Link>.
-              </p>
-            </fieldset>
-          )}
-
-          <fieldset className={styles.group}>
-            <legend className={styles.legend}>DNS</legend>
-            <label className={styles.checkbox}>
-              <input
-                type="checkbox"
-                checked={state.useCloudflare}
-                onChange={(e) => set('useCloudflare', e.target.checked)}
-              />
-              <span>Manage DNS with Cloudflare</span>
-            </label>
-            {state.useCloudflare && (
-              <label className={styles.field}>
-                <span className={styles.label}>dns.cloudflare.zone_id</span>
-                <input
-                  className={styles.input}
-                  placeholder="<your-cloudflare-zone-id>"
-                  value={state.zoneId}
-                  onChange={(e) => set('zoneId', e.target.value)}
-                />
-              </label>
-            )}
-          </fieldset>
+              {state.useCloudflare && (
+                <div className={styles.zoneWrap}>
+                  <LabeledField label="Zone id" schemaKey="dns.cloudflare.zone_id" required>
+                    <input
+                      className={styles.input}
+                      placeholder="<your-cloudflare-zone-id>"
+                      value={state.zoneId}
+                      onChange={(e) => set('zoneId', e.target.value)}
+                    />
+                  </LabeledField>
+                </div>
+              )}
+            </div>
+          </Section>
         </form>
 
         <div className={styles.output}>
           <div className={styles.outputHead}>
             <span className={styles.outputTitle}>nebari-config.yaml</span>
-            <span className={styles.starterBadge}>starter</span>
+            <span className={styles.spacer} />
+            <button type="button" className={styles.btn} onClick={download}>
+              Download
+            </button>
           </div>
-          <CodeBlock language="yaml" title="nebari-config.yaml">
-            {yaml}
-          </CodeBlock>
+          <CodeBlock language="yaml">{yaml}</CodeBlock>
         </div>
       </div>
     </div>

--- a/docs/src/components/NicConfigBuilder/index.tsx
+++ b/docs/src/components/NicConfigBuilder/index.tsx
@@ -5,60 +5,178 @@ import React, { useEffect, useMemo, useState } from 'react';
 import styles from './styles.module.css';
 
 /**
- * NicConfigBuilder is a guided starter for `nebari-config.yaml`. It asks for a
- * cloud provider, a DNS provider, and a handful of always-required fields, then
- * emits a minimal but valid-shaped config to copy. It is intentionally curated
- * rather than schema-driven: the full field set lives in the
- * [Configuration schema](/docs/references/config-schema) reference, and the
- * emitted file is a starting point to refine and check with `nic validate`.
+ * NicConfigBuilder is a guided starter for `nebari-config.yaml`. The provider
+ * list and each provider's structure (region key, node-group shape, whether a
+ * dedicated Longhorn storage pool is expressible) are derived at build time from
+ * the same JSON Schema the CLI validates against, for the selected NIC version.
+ *
+ * The one thing the schema does not carry is region/machine-type *values* (they
+ * are free-form strings), so a small curated map supplies suggestions for them;
+ * the fields stay editable. The emitted file is a starting point to refine and
+ * check with `nic validate`.
  */
 
-type ProviderKey = 'aws' | 'gcp' | 'azure' | 'hetzner';
+const DEFAULT_REPO = 'nebari-dev/nebari-infrastructure-core';
+const DEFAULT_REF = 'feat/config-schema-gen-v2';
 
-type ProviderMeta = {
-  label: string;
-  // `stub: true` means the cloud is supported by NIC but not yet wired into this
-  // builder; its tab shows a hand-off notice instead of a form. To enable a
-  // provider, drop `stub` and fill the fields below with values confirmed
-  // against the schema (do not guess).
-  stub?: boolean;
-  regionLabel?: string;
-  regions?: string[];
-  instances?: string[];
-  // Node-group shape the provider's schema expects: 'aws' uses
-  // instance/min_nodes/max_nodes; 'hetzner' uses instance_type/count and needs a
-  // master group. kubernetes_version is required by every provider's schema.
-  nodeShape?: 'aws' | 'hetzner';
-  kubernetesVersion?: string;
-  // Whether the provider can express a dedicated Longhorn storage node group.
-  // Requires per-node-group labels/taints, which the Hetzner schema lacks.
-  dedicatedStorage?: boolean;
-};
+const schemasBase = (repo: string, ref: string) =>
+  `https://raw.githubusercontent.com/${repo}/${ref}/schemas`;
 
-const PROVIDERS: Record<ProviderKey, ProviderMeta> = {
+// The only non-schema data: region/instance suggestions and a starter
+// kubernetes_version per provider (the schema has none of these as values).
+// Providers absent here still work — region/instance become free-text.
+type Hint = { label: string; k8s: string; regions: string[]; instances: string[] };
+
+const CURATED_HINTS: Record<string, Hint> = {
   aws: {
     label: 'AWS',
-    regionLabel: 'region',
+    k8s: '1.34',
     regions: ['us-west-2', 'us-east-1', 'eu-west-1', 'ap-southeast-2'],
     instances: ['m5.large', 'm5.xlarge', 'm5.2xlarge'],
-    nodeShape: 'aws',
-    kubernetesVersion: '1.34',
-    dedicatedStorage: true,
   },
-  gcp: { label: 'GCP', stub: true },
-  azure: { label: 'Azure', stub: true },
   hetzner: {
     label: 'Hetzner',
-    regionLabel: 'location',
+    k8s: '1.32',
     regions: ['fsn1', 'nbg1', 'hel1', 'ash', 'hil', 'sin'],
     instances: ['cpx21', 'cpx31', 'cpx41', 'cpx51'],
-    nodeShape: 'hetzner',
-    kubernetesVersion: '1.32',
   },
+  gcp: { label: 'GCP', k8s: '1.32', regions: [], instances: [] },
+  azure: { label: 'Azure', k8s: '1.32', regions: [], instances: [] },
 };
 
+type JSONSchema = {
+  type?: string | string[];
+  properties?: Record<string, JSONSchema>;
+  $defs?: Record<string, JSONSchema>;
+};
+
+type Derived = {
+  name: string;
+  label: string;
+  regionKey: 'region' | 'location';
+  nodeShape: 'aws' | 'hetzner';
+  dedicatedStorage: boolean;
+  regions: string[];
+  instances: string[];
+  k8s: string;
+};
+
+// Derive a provider's shape from its schema. Returns null for providers with no
+// region/node-groups (existing, local) — not buildable as a greenfield starter.
+function deriveProvider(name: string, doc: JSONSchema): Derived | null {
+  const defs = doc.$defs ?? {};
+  const cfg = Object.entries(defs).find(([k]) => k.endsWith('.Config'))?.[1];
+  const props = cfg?.properties ?? {};
+  const hasRegion = 'region' in props;
+  const hasLocation = 'location' in props;
+  if (!hasRegion && !hasLocation) {
+    return null;
+  }
+  const ng = Object.entries(defs).find(([k]) => k.toLowerCase().endsWith('nodegroup'))?.[1];
+  const ngProps = ng?.properties ?? {};
+  if (Object.keys(ngProps).length === 0) {
+    return null;
+  }
+  const hint = CURATED_HINTS[name];
+  return {
+    name,
+    label: hint?.label ?? name.toUpperCase(),
+    regionKey: hasLocation ? 'location' : 'region',
+    nodeShape: 'instance_type' in ngProps ? 'hetzner' : 'aws',
+    dedicatedStorage: 'longhorn' in props && 'labels' in ngProps && 'taints' in ngProps,
+    regions: hint?.regions ?? [],
+    instances: hint?.instances ?? [],
+    k8s: hint?.k8s ?? '1.32',
+  };
+}
+
+function useProviders(repo: string, ref: string) {
+  const [data, setData] = useState<Derived[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const base = schemasBase(repo, ref);
+    setLoading(true);
+    setError(null);
+
+    async function load() {
+      try {
+        const mres = await fetch(`${base}/manifest.json`, {
+          headers: { Accept: 'application/json' },
+        });
+        if (!mres.ok) {
+          throw new Error(`Failed to fetch manifest.json: ${mres.status} ${mres.statusText}`);
+        }
+        const manifest = (await mres.json()) as { providers?: string[] };
+        const derived = await Promise.all(
+          (manifest.providers ?? []).map(async (name) => {
+            const r = await fetch(`${base}/providers/${name}.json`, {
+              headers: { Accept: 'application/json' },
+            });
+            if (!r.ok) {
+              return null;
+            }
+            return deriveProvider(name, (await r.json()) as JSONSchema);
+          }),
+        );
+        if (!cancelled) {
+          setData(derived.filter((d): d is Derived => d !== null));
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, ref]);
+
+  return { data, loading, error };
+}
+
+type VersionOption = { value: string; label: string };
+const PREVIEW_OPTION: VersionOption = { value: DEFAULT_REF, label: `${DEFAULT_REF} (preview)` };
+
+// Upstream release tags, so the builder can target a specific NIC version.
+// Non-fatal on failure — the preview option alone drives the builder.
+function useVersions(repo: string): VersionOption[] {
+  const [tags, setTags] = useState<VersionOption[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repo}/tags?per_page=100`, {
+          headers: { Accept: 'application/vnd.github+json' },
+        });
+        if (!res.ok) {
+          return;
+        }
+        const json = (await res.json()) as { name: string }[];
+        if (!cancelled) {
+          setTags(json.map((t) => ({ value: t.name, label: t.name })));
+        }
+      } catch {
+        /* preview option is enough */
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+  return [PREVIEW_OPTION, ...tags];
+}
+
 type BuilderState = {
-  provider: ProviderKey;
+  provider: string;
   projectName: string;
   domain: string;
   region: string;
@@ -79,12 +197,12 @@ type BuilderState = {
   zoneId: string;
 };
 
-const initialFor = (provider: ProviderKey): BuilderState => ({
-  provider,
+const INITIAL_STATE: BuilderState = {
+  provider: '',
   projectName: 'my-nebari',
   domain: 'nebari.example.com',
-  region: PROVIDERS[provider].regions?.[0] ?? '',
-  kubernetesVersion: PROVIDERS[provider].kubernetesVersion ?? '',
+  region: '',
+  kubernetesVersion: '',
   certType: 'letsencrypt',
   acmeEmail: 'admin@example.com',
   gitUrl: 'https://github.com/my-org/my-nebari-config.git',
@@ -93,16 +211,15 @@ const initialFor = (provider: ProviderKey): BuilderState => ({
   gitAuthMethod: 'token',
   gitEnvVar: 'GIT_TOKEN',
   nodeGroupName: 'general',
-  instance: PROVIDERS[provider].instances?.[0] ?? '',
+  instance: '',
   minNodes: 1,
   maxNodes: 5,
   dedicatedStorage: false,
   useCloudflare: true,
   zoneId: '',
-});
+};
 
-function buildYaml(s: BuilderState): string {
-  const meta = PROVIDERS[s.provider];
+function buildYaml(s: BuilderState, d: Derived): string {
   const lines: string[] = [];
 
   lines.push(`project_name: ${s.projectName || 'my-nebari'}`);
@@ -128,13 +245,13 @@ function buildYaml(s: BuilderState): string {
     }`,
   );
 
-  const k8s = s.kubernetesVersion || meta.kubernetesVersion || '';
+  const k8s = s.kubernetesVersion || d.k8s;
   const group = s.nodeGroupName || 'general';
 
   lines.push('cluster:');
   lines.push(`  ${s.provider}:`);
 
-  if (meta.nodeShape === 'hetzner') {
+  if (d.nodeShape === 'hetzner') {
     // Hetzner (k3s) needs exactly one master node group; the builder adds it and
     // treats the named group as workers. Node groups use instance_type/count.
     const workers = group === 'master' ? 'workers' : group;
@@ -149,8 +266,8 @@ function buildYaml(s: BuilderState): string {
     lines.push(`        instance_type: ${s.instance}`);
     lines.push(`        count: ${s.maxNodes}`);
   } else {
-    const dedicated = s.dedicatedStorage && meta.dedicatedStorage;
-    lines.push(`    region: ${s.region}`);
+    const dedicated = s.dedicatedStorage && d.dedicatedStorage;
+    lines.push(`    ${d.regionKey}: ${s.region}`);
     lines.push(`    kubernetes_version: "${k8s}"`);
     lines.push('    node_groups:');
     lines.push(`      ${group}:`);
@@ -241,12 +358,16 @@ function Section({ label, children }: { label: string; children: React.ReactNode
 }
 
 export default function NicConfigBuilder(): JSX.Element {
-  const [state, setState] = useState<BuilderState>(() => initialFor('aws'));
+  const [selectedRef, setSelectedRef] = useState(DEFAULT_REF);
+  const versions = useVersions(DEFAULT_REPO);
+  const { data: providers, loading, error } = useProviders(DEFAULT_REPO, selectedRef);
+  const [state, setState] = useState<BuilderState>(INITIAL_STATE);
   const [modalOpen, setModalOpen] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
-  const meta = PROVIDERS[state.provider];
-  const yaml = useMemo(() => buildYaml(state), [state]);
-  const isHetzner = meta.nodeShape === 'hetzner';
+
+  const derived = providers?.find((p) => p.name === state.provider) ?? null;
+  const isHetzner = derived?.nodeShape === 'hetzner';
+  const yaml = useMemo(() => (derived ? buildYaml(state, derived) : ''), [state, derived]);
 
   // Restore state from a shared link and show the config front-and-centre.
   useEffect(() => {
@@ -258,13 +379,33 @@ export default function NicConfigBuilder(): JSX.Element {
       return;
     }
     try {
-      const decoded = decodeState(c);
-      setState((prev) => ({ ...prev, ...decoded }));
+      setState((prev) => ({ ...prev, ...decodeState(c) }));
       setModalOpen(true);
     } catch {
       /* ignore malformed share links */
     }
   }, []);
+
+  // Once providers load, pick a default provider (and its suggested defaults)
+  // unless the state already names a valid one (e.g. from a shared link).
+  useEffect(() => {
+    if (!providers || providers.length === 0) {
+      return;
+    }
+    setState((prev) => {
+      if (prev.provider && providers.some((p) => p.name === prev.provider)) {
+        return prev;
+      }
+      const p = providers[0];
+      return {
+        ...prev,
+        provider: p.name,
+        region: p.regions[0] ?? prev.region,
+        instance: p.instances[0] ?? prev.instance,
+        kubernetesVersion: prev.kubernetesVersion || p.k8s,
+      };
+    });
+  }, [providers]);
 
   useEffect(() => {
     if (!modalOpen) {
@@ -297,16 +438,16 @@ export default function NicConfigBuilder(): JSX.Element {
   const set = <K extends keyof BuilderState>(key: K, value: BuilderState[K]) =>
     setState((prev) => ({ ...prev, [key]: value }));
 
-  // Switching provider resets the per-provider defaults (region, instance,
-  // kubernetes_version) to that provider's values.
-  const changeProvider = (provider: ProviderKey) =>
+  const changeProvider = (name: string) => {
+    const p = providers?.find((x) => x.name === name);
     setState((prev) => ({
       ...prev,
-      provider,
-      region: PROVIDERS[provider].regions?.[0] ?? '',
-      instance: PROVIDERS[provider].instances?.[0] ?? '',
-      kubernetesVersion: PROVIDERS[provider].kubernetesVersion ?? '',
+      provider: name,
+      region: p?.regions[0] ?? '',
+      instance: p?.instances[0] ?? '',
+      kubernetesVersion: p?.k8s ?? prev.kubernetesVersion,
     }));
+  };
 
   const download = () => {
     const blob = new Blob([yaml], { type: 'text/yaml' });
@@ -320,24 +461,71 @@ export default function NicConfigBuilder(): JSX.Element {
     setTimeout(() => URL.revokeObjectURL(url), 2000);
   };
 
+  const isPreview = selectedRef === DEFAULT_REF;
+  const versionBar = (
+    <div className={styles.versionBar}>
+      <label className={styles.versionLabel} htmlFor="nic-builder-version">
+        NIC version
+      </label>
+      <select
+        id="nic-builder-version"
+        className={styles.input}
+        value={selectedRef}
+        onChange={(e) => setSelectedRef(e.target.value)}
+      >
+        {versions.map((v) => (
+          <option key={v.value} value={v.value}>
+            {v.label}
+          </option>
+        ))}
+      </select>
+      {isPreview && <span className={styles.previewBadge}>unreleased</span>}
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div className={styles.wrapper}>
+        {versionBar}
+        <p>Loading providers from the {selectedRef} schema…</p>
+      </div>
+    );
+  }
+
+  if (error || !providers || providers.length === 0) {
+    return (
+      <div className={styles.wrapper}>
+        {versionBar}
+        <div className={styles.stub}>
+          <div className={styles.stubTitle}>Could not load the schema</div>
+          <p>
+            No provider schema was found for <code>{selectedRef}</code>. Release tags carry a
+            schema only once <code>schemas/</code> ships in that version; pick the preview
+            entry, or write the config by hand from the{' '}
+            <Link to="/docs/references/config-schema">configuration schema</Link>.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   const providerCards = (
     <div>
       <div className={styles.providerLabel}>Cloud provider</div>
       <div className={styles.providerCards}>
-        {(Object.keys(PROVIDERS) as ProviderKey[]).map((key) => {
-          const p = PROVIDERS[key];
-          const active = state.provider === key;
+        {providers.map((p) => {
+          const active = state.provider === p.name;
           return (
             <button
-              key={key}
+              key={p.name}
               type="button"
-              className={`${styles.providerCard} ${active ? styles.providerCardActive : ''} ${
-                p.stub ? styles.providerCardStub : ''
-              }`}
-              onClick={() => changeProvider(key)}
+              className={`${styles.providerCard} ${active ? styles.providerCardActive : ''}`}
+              onClick={() => changeProvider(p.name)}
             >
               <span className={styles.providerName}>{p.label}</span>
-              <span className={styles.providerStatus}>{p.stub ? 'Not wired yet' : 'Ready'}</span>
+              <span className={styles.providerStatus}>
+                {p.regions.length ? 'Suggested values' : 'Free-text values'}
+              </span>
             </button>
           );
         })}
@@ -345,28 +533,18 @@ export default function NicConfigBuilder(): JSX.Element {
     </div>
   );
 
-  // A supported cloud that this builder does not yet cover: hand the reader off
-  // to the schema reference rather than emitting a half-guessed config.
-  if (meta.stub) {
+  if (!derived) {
     return (
       <div className={styles.wrapper}>
+        {versionBar}
         {providerCards}
-        <div className={styles.stub}>
-          <div className={styles.stubTitle}>Not wired into this builder yet</div>
-          <p>
-            NIC supports {meta.label}, but its regions and machine types are not confirmed
-            against the schema, so the builder will not guess them.
-          </p>
-          <Link className={styles.stubLink} to="/docs/references/config-schema">
-            Write it from the schema →
-          </Link>
-        </div>
       </div>
     );
   }
 
   return (
     <div className={styles.wrapper}>
+      {versionBar}
       <div className={styles.builder}>
         <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
           {providerCards}
@@ -472,20 +650,20 @@ export default function NicConfigBuilder(): JSX.Element {
             <div className={styles.grid2}>
               <LabeledField
                 label={isHetzner ? 'Location' : 'Region'}
-                schemaKey={`cluster.${state.provider}.${meta.regionLabel ?? 'region'}`}
+                schemaKey={`cluster.${state.provider}.${derived.regionKey}`}
                 required
               >
-                <select
+                <input
                   className={styles.input}
+                  list={`regions-${derived.name}`}
                   value={state.region}
                   onChange={(e) => set('region', e.target.value)}
-                >
-                  {(meta.regions ?? []).map((r) => (
-                    <option key={r} value={r}>
-                      {r}
-                    </option>
+                />
+                <datalist id={`regions-${derived.name}`}>
+                  {derived.regions.map((r) => (
+                    <option key={r} value={r} />
                   ))}
-                </select>
+                </datalist>
               </LabeledField>
               <LabeledField label="Kubernetes version" schemaKey="kubernetes_version" required>
                 <input
@@ -515,17 +693,17 @@ export default function NicConfigBuilder(): JSX.Element {
                 schemaKey={isHetzner ? 'instance_type' : 'instance'}
                 required
               >
-                <select
+                <input
                   className={styles.input}
+                  list={`instances-${derived.name}`}
                   value={state.instance}
                   onChange={(e) => set('instance', e.target.value)}
-                >
-                  {(meta.instances ?? []).map((i) => (
-                    <option key={i} value={i}>
-                      {i}
-                    </option>
+                />
+                <datalist id={`instances-${derived.name}`}>
+                  {derived.instances.map((i) => (
+                    <option key={i} value={i} />
                   ))}
-                </select>
+                </datalist>
               </LabeledField>
               {isHetzner ? (
                 <LabeledField label="Count" schemaKey="count" required>
@@ -564,7 +742,7 @@ export default function NicConfigBuilder(): JSX.Element {
 
           <Section label="Options">
             <div className={styles.options}>
-              {meta.dedicatedStorage && (
+              {derived.dedicatedStorage && (
                 <label className={styles.option}>
                   <input
                     type="checkbox"
@@ -654,7 +832,12 @@ export default function NicConfigBuilder(): JSX.Element {
             </div>
             <div className={styles.shareRow}>
               <span className={styles.shareLabel}>Share link</span>
-              <input className={styles.input} readOnly value={shareUrl} onFocus={(e) => e.target.select()} />
+              <input
+                className={styles.input}
+                readOnly
+                value={shareUrl}
+                onFocus={(e) => e.target.select()}
+              />
               <button type="button" className={styles.btn} onClick={copyLink}>
                 {copiedLink ? 'Copied' : 'Copy link'}
               </button>

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -1,11 +1,34 @@
 /* Guided config builder: a form on the left, live YAML on the right. Colors ride
    on Infima theme variables, so it follows light/dark automatically. */
+.wrapper {
+  margin: 1.5rem 0;
+}
+
+/* Provider selector spans the full width above the two-column body. */
+.wrapper > .group {
+  margin-bottom: 18px;
+}
+
 .builder {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 32px;
   align-items: start;
-  margin: 1.5rem 0;
+}
+
+/* Hand-off notice shown for a supported cloud the builder does not cover yet. */
+.stub {
+  padding: 20px 22px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+}
+
+.stub p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
 }
 
 .form {

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -4,6 +4,45 @@
   margin: 1.5rem 0;
 }
 
+/* ---- version selector ---- */
+.versionBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  margin-bottom: 22px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+}
+
+.versionLabel {
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.versionBar .input {
+  width: auto;
+  font-size: 12.5px;
+  padding: 5px 8px;
+}
+
+.previewBadge {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: var(--ifm-color-warning-dark, #8a5a00);
+  background: var(--ifm-color-warning-contrast-background, #fdf4e3);
+  border: 1px solid currentColor;
+}
+
 /* ---- provider cards ---- */
 .providerLabel {
   font-size: 10.5px;

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -103,7 +103,9 @@
 /* ---- two-column body: form + sticky output ---- */
 .builder {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 380px);
+  /* ~55% form / ~45% YAML; both tracks can shrink so long lines scroll inside
+     the code block rather than widening the layout. */
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
   gap: 28px;
   align-items: start;
 }

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -257,6 +257,8 @@
 
 /* ---- stub hand-off ---- */
 .stub {
+  max-width: 560px;
+  margin-top: 22px;
   padding: 22px 24px;
   border: 1px dashed var(--ifm-color-emphasis-300);
   border-radius: 9px;

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -1,146 +1,221 @@
-/* Guided config builder: a form on the left, live YAML on the right. Colors ride
-   on Infima theme variables, so it follows light/dark automatically. */
+/* Guided config builder (single-form layout). Colors ride on Infima theme
+   variables, so the form follows light/dark automatically. */
 .wrapper {
   margin: 1.5rem 0;
 }
 
-/* Provider selector spans the full width above the two-column body. */
-.wrapper > .group {
-  margin-bottom: 18px;
+/* ---- provider cards ---- */
+.providerLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 9px;
 }
 
+.providerCards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 26px;
+}
+
+.providerCard {
+  text-align: left;
+  cursor: pointer;
+  padding: 11px 13px;
+  border: 1.5px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+.providerCard:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.providerCardActive {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary-contrast-background);
+}
+
+.providerCardStub .providerName {
+  color: var(--ifm-color-emphasis-600);
+}
+
+.providerName {
+  display: block;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.providerStatus {
+  display: block;
+  font-size: 10.5px;
+  margin-top: 3px;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.providerCardActive .providerStatus {
+  color: var(--ifm-color-primary-dark);
+}
+
+/* ---- two-column body: form + sticky output ---- */
 .builder {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 32px;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 28px;
   align-items: start;
-}
-
-/* Hand-off notice shown for a supported cloud the builder does not cover yet. */
-.stub {
-  padding: 20px 22px;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: var(--ifm-global-radius);
-  background: var(--ifm-background-surface-color);
-}
-
-.stub p {
-  margin: 0;
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--ifm-color-emphasis-700);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 24px;
   min-width: 0;
 }
 
-.group {
-  margin: 0;
-  padding: 14px 16px 16px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: var(--ifm-global-radius);
-  background: var(--ifm-background-surface-color);
+/* ---- section ---- */
+.sectionHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 13px;
 }
 
-.legend {
-  padding: 0 6px;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+.sectionLabel {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
-  color: var(--ifm-color-emphasis-700);
+  color: var(--ifm-color-emphasis-600);
 }
 
-.row {
+.rule {
+  flex: 1;
+  height: 1px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.sectionNote {
+  margin: -8px 0 13px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* ---- field grids ---- */
+.grid2 {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 14px;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 18px;
 }
 
-.row + .row {
-  margin-top: 14px;
+.gridNode {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 0.7fr 0.7fr;
+  gap: 16px 14px;
+}
+
+.gridNodeHetzner {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr 0.7fr;
+  gap: 16px 14px;
 }
 
 .field {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
   min-width: 0;
 }
 
-.label {
+.fieldLabelRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 5px;
+}
+
+.fieldLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+.req {
+  color: var(--ifm-color-primary);
+  margin-left: 3px;
+}
+
+.fieldKey {
   font-family: var(--ifm-font-family-monospace);
-  font-size: 12px;
-  color: var(--ifm-color-emphasis-700);
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-500);
   overflow-wrap: anywhere;
 }
 
 .input {
   width: 100%;
-  padding: 7px 9px;
-  font-size: 14px;
+  box-sizing: border-box;
   font-family: var(--ifm-font-family-monospace);
+  font-size: 13.5px;
   color: var(--ifm-font-color-base);
-  background: var(--ifm-background-color);
+  padding: 9px 11px;
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: var(--ifm-global-radius);
+  border-radius: 6px;
+  background: var(--ifm-background-color);
+  outline: none;
 }
 
 .input:focus {
-  outline: none;
   border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 2px var(--ifm-color-primary-contrast-background);
+  box-shadow: 0 0 0 3px var(--ifm-color-primary-contrast-background);
 }
 
-.pills {
+/* ---- options (checkboxes with descriptions) ---- */
+.options {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex-direction: column;
+  gap: 11px;
 }
 
-.pill {
-  font-family: var(--ifm-font-family-monospace);
+.option {
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.option input {
+  margin: 2px 0 0;
+  width: 15px;
+  height: 15px;
+  accent-color: var(--ifm-color-primary);
+  flex: none;
+}
+
+.optionTitle {
+  display: block;
   font-size: 13px;
-  padding: 6px 14px;
-  cursor: pointer;
-  color: var(--ifm-color-emphasis-700);
-  background: var(--ifm-background-color);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: var(--ifm-global-radius);
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
 }
 
-.pill:hover {
-  border-color: var(--ifm-color-primary);
-}
-
-.pillActive {
-  font-weight: 650;
-  color: var(--ifm-color-primary-dark);
-  background: var(--ifm-color-primary-contrast-background);
-  border-color: var(--ifm-color-primary);
-}
-
-.checkbox {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: var(--ifm-color-emphasis-800);
-  cursor: pointer;
-  margin-bottom: 12px;
-}
-
-.hint {
-  margin: 0;
-  font-size: 12.5px;
+.optionDesc {
+  display: block;
+  font-size: 12px;
   line-height: 1.5;
   color: var(--ifm-color-emphasis-600);
+  margin-top: 2px;
 }
 
+.zoneWrap {
+  margin-left: 26px;
+  max-width: 340px;
+}
+
+/* ---- sticky output ---- */
 .output {
   position: sticky;
   top: calc(var(--ifm-navbar-height) + 16px);
@@ -150,7 +225,7 @@
 .outputHead {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   margin-bottom: 8px;
 }
 
@@ -161,22 +236,83 @@
   color: var(--ifm-color-emphasis-800);
 }
 
-.starterBadge {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  padding: 2px 8px;
-  border-radius: 999px;
-  color: var(--ifm-color-emphasis-700);
-  background: var(--ifm-color-emphasis-200);
+.spacer {
+  flex: 1;
 }
 
+.btn {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 5px;
+  padding: 5px 9px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-dark);
+}
+
+/* ---- stub hand-off ---- */
+.stub {
+  padding: 22px 24px;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: 9px;
+  background: var(--ifm-background-surface-color);
+}
+
+.stubTitle {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ifm-font-color-base);
+  margin-bottom: 7px;
+}
+
+.stub p {
+  margin: 0 0 16px;
+  max-width: 52ch;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.stubLink {
+  display: inline-block;
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 8px 13px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  text-decoration: none;
+}
+
+.hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* ---- responsive ---- */
 @media (max-width: 996px) {
   .builder {
     grid-template-columns: minmax(0, 1fr);
   }
   .output {
     position: static;
+  }
+}
+
+@media (max-width: 600px) {
+  .providerCards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .grid2,
+  .gridNode,
+  .gridNodeHetzner {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -134,6 +134,13 @@
   margin-bottom: 12px;
 }
 
+.hint {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-600);
+}
+
 .output {
   position: sticky;
   top: calc(var(--ifm-navbar-height) + 16px);

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -18,7 +18,6 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 8px;
-  margin-bottom: 26px;
 }
 
 .providerCard {

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -64,7 +64,7 @@
 /* ---- two-column body: form + sticky output ---- */
 .builder {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 380px);
   gap: 28px;
   align-items: start;
 }

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -358,7 +358,7 @@
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  background: var(--ifm-background-color);
+  background: var(--ifm-background-surface-color);
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 10px;
   box-shadow: 0 12px 44px rgba(0, 0, 0, 0.35);
@@ -370,7 +370,7 @@
   align-items: center;
   gap: 8px;
   padding: 12px 14px;
-  background: var(--ifm-background-color);
+  background: var(--ifm-background-surface-color);
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -297,6 +297,63 @@
   color: var(--ifm-color-emphasis-600);
 }
 
+/* ---- share modal ---- */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.dialog {
+  width: 100%;
+  max-width: 720px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  box-shadow: 0 12px 44px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.dialogHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.dialogBody {
+  padding: 14px 14px 0;
+  overflow: auto;
+}
+
+.shareRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.shareLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  white-space: nowrap;
+}
+
+.shareRow .input {
+  font-size: 12px;
+}
+
 /* ---- responsive ---- */
 @media (max-width: 996px) {
   .builder {

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -1,0 +1,152 @@
+/* Guided config builder: a form on the left, live YAML on the right. Colors ride
+   on Infima theme variables, so it follows light/dark automatically. */
+.builder {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 32px;
+  align-items: start;
+  margin: 1.5rem 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+.group {
+  margin: 0;
+  padding: 14px 16px 16px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-surface-color);
+}
+
+.legend {
+  padding: 0 6px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.row + .row {
+  margin-top: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.label {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12px;
+  color: var(--ifm-color-emphasis-700);
+  overflow-wrap: anywhere;
+}
+
+.input {
+  width: 100%;
+  padding: 7px 9px;
+  font-size: 14px;
+  font-family: var(--ifm-font-family-monospace);
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px var(--ifm-color-primary-contrast-background);
+}
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pill {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13px;
+  padding: 6px 14px;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+}
+
+.pill:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.pillActive {
+  font-weight: 650;
+  color: var(--ifm-color-primary-dark);
+  background: var(--ifm-color-primary-contrast-background);
+  border-color: var(--ifm-color-primary);
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--ifm-color-emphasis-800);
+  cursor: pointer;
+  margin-bottom: 12px;
+}
+
+.output {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 16px);
+  min-width: 0;
+}
+
+.outputHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.outputTitle {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.starterBadge {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-200);
+}
+
+@media (max-width: 996px) {
+  .builder {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .output {
+    position: static;
+  }
+}

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -370,8 +370,15 @@
 }
 
 .dialogBody {
-  padding: 14px 14px 0;
+  padding: 14px;
   overflow: auto;
+}
+
+/* Let the code block sit flush in the padded body (Docusaurus adds its own
+   bottom margin, which throws off the modal's spacing). */
+.dialogBody :global(.theme-code-block),
+.dialogBody :global(pre) {
+  margin-bottom: 0;
 }
 
 .shareRow {
@@ -380,6 +387,7 @@
   gap: 8px;
   padding: 12px 14px;
   border-top: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-surface-color);
 }
 
 .shareLabel {
@@ -389,8 +397,28 @@
   white-space: nowrap;
 }
 
+/* The link fills the row; the label and button keep their intrinsic size. */
 .shareRow .input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
   font-size: 12px;
+}
+
+.iconBtn {
+  font-size: 13px;
+  line-height: 1;
+  color: var(--ifm-color-emphasis-600);
+  background: none;
+  border: none;
+  border-radius: 5px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.iconBtn:hover {
+  color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-200);
 }
 
 /* ---- responsive ---- */

--- a/docs/src/components/NicConfigBuilder/styles.module.css
+++ b/docs/src/components/NicConfigBuilder/styles.module.css
@@ -340,7 +340,9 @@
 .overlay {
   position: fixed;
   inset: 0;
-  z-index: 200;
+  /* Above the Docusaurus fixed navbar (--ifm-z-index-fixed: 200) so the whole
+     page, navbar included, sits under the dimmed backdrop. */
+  z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -366,6 +368,7 @@
   align-items: center;
   gap: 8px;
   padding: 12px 14px;
+  background: var(--ifm-background-color);
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
 }
 

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -1,0 +1,421 @@
+import Admonition from '@theme/Admonition';
+import Details from '@theme/Details';
+import Heading from '@theme/Heading';
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+import React, { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+/**
+ * NicSchemaLoader renders the Nebari Infrastructure Core (NIC) configuration
+ * reference directly from the JSON Schema that `nebari-infrastructure-core`
+ * generates from its Go config structs (the `schemas/` directory produced by
+ * `make schemas`). Because the schema is generated from the source of truth,
+ * this page cannot drift from the actual config contract.
+ *
+ * Producer contract (schemas/manifest.json):
+ *   { "providers": [...], "dns": [...], "top_level": "nebari-config.json" }
+ * Each referenced file is a self-contained JSON Schema whose root `$ref`
+ * points into its own `$defs` (e.g. `#/$defs/aws.Config`).
+ */
+
+type JSONSchema = {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  items?: JSONSchema;
+  enum?: unknown[];
+  default?: unknown;
+  pattern?: string;
+  additionalProperties?: boolean | JSONSchema;
+  $ref?: string;
+};
+
+type Manifest = {
+  providers: string[];
+  dns: string[];
+  top_level: string;
+};
+
+type LoadedSchemas = {
+  topLevel: JSONSchema;
+  cluster: { name: string; schema: JSONSchema }[];
+  dns: { name: string; schema: JSONSchema }[];
+};
+
+// Source of truth. Once the schema-generation pipeline
+// (nebari-infrastructure-core#362) lands on a tagged release, pin `ref` to
+// that tag for versioned docs; until then it tracks the feature branch.
+const DEFAULT_REPO = 'nebari-dev/nebari-infrastructure-core';
+const DEFAULT_REF = 'feat/config-schema-gen';
+
+const schemasBase = (repo: string, ref: string) =>
+  `https://raw.githubusercontent.com/${repo}/${ref}/schemas`;
+
+const slug = (name: string) => name.replace(/_/g, '-').toLowerCase();
+
+const refKey = (ref: string) => ref.replace('#/$defs/', '');
+
+/**
+ * Inline every internal `#/$defs/...` reference against the file's own `$defs`
+ * map. The generated schemas only ever use same-file pointer refs, so a local
+ * dereference is sufficient - and necessary, because generic `$ref` resolvers
+ * leave these recursive `$defs` refs untouched. `seen` guards against cycles
+ * (a Go type that transitively references itself), returning a plain object
+ * stub instead of recursing forever.
+ */
+function deref(
+  node: JSONSchema,
+  defs: Record<string, JSONSchema>,
+  seen: Set<string>,
+): JSONSchema {
+  if (node === null || typeof node !== 'object') {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map((n) => deref(n, defs, seen)) as unknown as JSONSchema;
+  }
+  if (typeof node.$ref === 'string') {
+    const key = refKey(node.$ref);
+    if (seen.has(key) || !defs[key]) {
+      return { type: 'object', description: node.description };
+    }
+    const target = deref(defs[key], defs, new Set(seen).add(key));
+    // Preserve a description written on the ref site (invopop puts the field
+    // doc there) unless the target already carries its own.
+    return node.description && !target.description
+      ? { ...target, description: node.description }
+      : target;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(node)) {
+    if (k === '$defs') {
+      continue;
+    }
+    out[k] = deref(v as JSONSchema, defs, seen);
+  }
+  return out as JSONSchema;
+}
+
+/**
+ * Fetch one schema file and return the object its top-level `$ref` points to,
+ * with every nested `$ref` inlined. Provider schemas are self-contained.
+ */
+async function loadSchemaFile(base: string, path: string): Promise<JSONSchema> {
+  const res = await fetch(`${base}/${path}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${path}: ${res.status} ${res.statusText}`);
+  }
+  const doc = (await res.json()) as JSONSchema & { $defs?: Record<string, JSONSchema> };
+  const defs = doc.$defs ?? {};
+  const entryKey = typeof doc.$ref === 'string' ? refKey(doc.$ref) : null;
+  const entry = entryKey && defs[entryKey] ? defs[entryKey] : doc;
+  return deref(entry, defs, new Set(entryKey ? [entryKey] : []));
+}
+
+function useNicSchemas(repo: string, ref: string) {
+  const [data, setData] = useState<LoadedSchemas | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const base = schemasBase(repo, ref);
+
+    async function load() {
+      try {
+        const manifestRes = await fetch(`${base}/manifest.json`, {
+          headers: { Accept: 'application/json' },
+        });
+        if (!manifestRes.ok) {
+          throw new Error(
+            `Failed to fetch manifest.json: ${manifestRes.status} ${manifestRes.statusText}`,
+          );
+        }
+        const manifest: Manifest = await manifestRes.json();
+
+        const [topLevel, cluster, dns] = await Promise.all([
+          loadSchemaFile(base, manifest.top_level),
+          Promise.all(
+            manifest.providers.map(async (name) => ({
+              name,
+              schema: await loadSchemaFile(base, `providers/${name}.json`),
+            })),
+          ),
+          Promise.all(
+            manifest.dns.map(async (name) => ({
+              name,
+              schema: await loadSchemaFile(base, `providers/${name}.json`),
+            })),
+          ),
+        ]);
+
+        if (!cancelled) {
+          setData({ topLevel, cluster, dns });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, ref]);
+
+  return { data, loading, error };
+}
+
+// A map type is a JSON-Schema object with no fixed properties whose value shape
+// is given by an `additionalProperties` schema (e.g. Go `map[string]NodeGroup`).
+function mapValueSchema(schema: JSONSchema): JSONSchema | null {
+  if (
+    schema.type === 'object' &&
+    !schema.properties &&
+    schema.additionalProperties &&
+    typeof schema.additionalProperties === 'object'
+  ) {
+    return schema.additionalProperties;
+  }
+  return null;
+}
+
+function typeLabel(schema: JSONSchema): string {
+  if (schema.enum) {
+    return 'enum';
+  }
+  if (schema.type === 'array') {
+    const it = schema.items;
+    const itType = it
+      ? Array.isArray(it.type)
+        ? it.type.join(' | ')
+        : it.type ?? (it.properties ? 'object' : 'any')
+      : 'any';
+    return `array<${itType}>`;
+  }
+  const mapValue = mapValueSchema(schema);
+  if (mapValue) {
+    return `map<${typeLabel(mapValue)}>`;
+  }
+  if (Array.isArray(schema.type)) {
+    return schema.type.join(' | ');
+  }
+  return schema.type ?? (schema.properties ? 'object' : 'any');
+}
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <tr>
+      <th style={{ textAlign: 'left', padding: '6px 12px', whiteSpace: 'nowrap' }}>
+        {label}
+      </th>
+      <td style={{ padding: '6px 12px', width: '100%' }}>{value}</td>
+    </tr>
+  );
+}
+
+function Field({
+  name,
+  schema,
+  required,
+  level,
+}: {
+  name: string;
+  schema: JSONSchema;
+  required: boolean;
+  level: number;
+}) {
+  const nestedObject = schema.type === 'object' && schema.properties;
+  const arrayOfObjects = schema.type === 'array' && schema.items?.properties;
+  const mapValue = mapValueSchema(schema);
+  const mapOfObjects = mapValue && mapValue.properties;
+  const headingLevel = Math.min(level, 6) as 2 | 3 | 4 | 5 | 6;
+
+  return (
+    <div style={{ marginBottom: '18px' }}>
+      <Heading as={`h${headingLevel}`} id={slug(name)}>
+        <code>{name}</code>{' '}
+        {required && <span className="badge badge--secondary">required</span>}
+      </Heading>
+
+      {schema.description && (
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          {schema.description}
+        </ReactMarkdown>
+      )}
+
+      <table style={{ borderCollapse: 'collapse', display: 'table' }}>
+        <tbody>
+          <DetailRow label="Type" value={<code>{typeLabel(schema)}</code>} />
+          {schema.enum && (
+            <DetailRow
+              label="Options"
+              value={<code>{schema.enum.map(String).join(', ')}</code>}
+            />
+          )}
+          {schema.pattern && (
+            <DetailRow label="Pattern" value={<code>{schema.pattern}</code>} />
+          )}
+          {schema.default !== undefined && (
+            <DetailRow
+              label="Default"
+              value={<code>{JSON.stringify(schema.default)}</code>}
+            />
+          )}
+        </tbody>
+      </table>
+
+      {nestedObject && (
+        <Details summary={<summary>Nested fields</summary>}>
+          <FieldList schema={schema} level={level + 1} />
+        </Details>
+      )}
+      {arrayOfObjects && (
+        <Details summary={<summary>Item fields</summary>}>
+          <FieldList schema={schema.items as JSONSchema} level={level + 1} />
+        </Details>
+      )}
+      {mapOfObjects && (
+        <Details summary={<summary>Value fields (one entry per key)</summary>}>
+          <FieldList schema={mapValue as JSONSchema} level={level + 1} />
+        </Details>
+      )}
+    </div>
+  );
+}
+
+function FieldList({ schema, level }: { schema: JSONSchema; level: number }) {
+  const properties = schema.properties ?? {};
+  const required = new Set(schema.required ?? []);
+  const entries = Object.entries(properties).sort(([a], [b]) => a.localeCompare(b));
+
+  if (entries.length === 0) {
+    return (
+      <Admonition type="note">
+        This section is keyed by provider name; see the provider-specific
+        reference below for its fields.
+      </Admonition>
+    );
+  }
+
+  return (
+    <>
+      {entries.map(([key, value]) => (
+        <Field
+          key={key}
+          name={key}
+          schema={value}
+          required={required.has(key)}
+          level={level}
+        />
+      ))}
+    </>
+  );
+}
+
+export default function NicSchemaLoader({
+  repo = DEFAULT_REPO,
+  ref = DEFAULT_REF,
+}: {
+  repo?: string;
+  ref?: string;
+}): JSX.Element {
+  const { data, loading, error } = useNicSchemas(repo, ref);
+
+  if (loading) {
+    return <p>Loading configuration schema…</p>;
+  }
+  if (error) {
+    return (
+      <Admonition type="danger" title="Could not load the configuration schema">
+        <p>{error}</p>
+        <p>
+          The reference is generated from{' '}
+          <a
+            href={`https://github.com/${repo}/tree/${ref}/schemas`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <code>{repo}</code> <code>schemas/</code>
+          </a>
+          .
+        </p>
+      </Admonition>
+    );
+  }
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <>
+      <Admonition type="info">
+        This reference is generated automatically from the{' '}
+        <a
+          href={`https://github.com/${repo}/tree/${ref}/schemas`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          NIC configuration JSON Schema
+        </a>{' '}
+        (currently tracking <code>{ref}</code>). It cannot drift from the config
+        the code actually accepts.
+      </Admonition>
+
+      <Heading as="h2" id="top-level">
+        Top-level configuration
+      </Heading>
+      <FieldList schema={data.topLevel} level={3} />
+
+      {data.cluster.length > 0 && (
+        <>
+          <Heading as="h2" id="cluster-providers">
+            Cluster providers
+          </Heading>
+          <p>
+            Configured under <code>cluster.&lt;provider&gt;</code>. Exactly one
+            provider is set per deployment.
+          </p>
+          <Tabs>
+            {data.cluster.map(({ name, schema }) => (
+              <TabItem key={name} value={name} label={name}>
+                <FieldList schema={schema} level={3} />
+              </TabItem>
+            ))}
+          </Tabs>
+        </>
+      )}
+
+      {data.dns.length > 0 && (
+        <>
+          <Heading as="h2" id="dns-providers">
+            DNS providers
+          </Heading>
+          <p>
+            Configured under <code>dns.&lt;provider&gt;</code>. Credentials (API
+            tokens) are read from environment variables, not from config.
+          </p>
+          <Tabs>
+            {data.dns.map(({ name, schema }) => (
+              <TabItem key={name} value={name} label={name}>
+                <FieldList schema={schema} level={3} />
+              </TabItem>
+            ))}
+          </Tabs>
+        </>
+      )}
+    </>
+  );
+}

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -495,6 +495,106 @@ function FieldList({
   );
 }
 
+type TocSection = {
+  id: string;
+  label: string;
+  children: { id: string; label: string }[];
+};
+
+// Build the right-side TOC from the loaded schema. The page hides Docusaurus's
+// native TOC (every field heading is rendered at runtime, so the static TOC is
+// empty); this mirrors the section headings plus the always-visible top-level
+// fields, in the same required-then-optional order FieldList renders them.
+// Provider fields live in mutually-exclusive tabs and collapsed Details, so the
+// TOC stops at the section heading for those rather than listing hidden anchors.
+function buildToc(data: LoadedSchemas): TocSection[] {
+  const props = data.topLevel.properties ?? {};
+  const required = new Set(data.topLevel.required ?? []);
+  const names = Object.keys(props);
+  const ordered = [
+    ...names.filter((n) => required.has(n)).sort(),
+    ...names.filter((n) => !required.has(n)).sort(),
+  ];
+
+  const sections: TocSection[] = [
+    {
+      id: 'top-level',
+      label: 'Top-level configuration',
+      children: ordered.map((n) => ({ id: pathId([n]), label: n })),
+    },
+  ];
+  if (data.cluster.length > 0) {
+    sections.push({ id: 'cluster-providers', label: 'Cluster providers', children: [] });
+  }
+  if (data.dns.length > 0) {
+    sections.push({ id: 'dns-providers', label: 'DNS providers', children: [] });
+  }
+  return sections;
+}
+
+// Highlight the entry nearest the top of the viewport as the reader scrolls.
+function useActiveId(ids: string[]): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const els = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (els.length === 0) {
+      return undefined;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '0px 0px -70% 0px', threshold: 0 },
+    );
+    els.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [ids.join('|')]);
+
+  return activeId;
+}
+
+function SchemaToc({ sections }: { sections: TocSection[] }): JSX.Element {
+  const ids = sections.flatMap((s) => [s.id, ...s.children.map((c) => c.id)]);
+  const activeId = useActiveId(ids);
+
+  const link = (id: string, label: string, extra: string) => (
+    <a
+      href={`#${id}`}
+      className={`${styles.tocLink} ${extra} ${activeId === id ? styles.tocLinkActive : ''}`}
+    >
+      {label}
+    </a>
+  );
+
+  return (
+    <nav className={styles.toc} aria-label="Configuration schema contents">
+      <div className={styles.tocTitle}>On this page</div>
+      <ul className={styles.tocList}>
+        {sections.map((s) => (
+          <li key={s.id}>
+            {link(s.id, s.label, styles.tocSection)}
+            {s.children.length > 0 && (
+              <ul className={styles.tocChildList}>
+                {s.children.map((c) => (
+                  <li key={c.id}>{link(c.id, c.label, styles.tocChild)}</li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
 export default function NicSchemaLoader({
   repo = DEFAULT_REPO,
   ref = DEFAULT_REF,
@@ -554,11 +654,16 @@ export default function NicSchemaLoader({
     body = renderSections(data);
   }
 
+  const sections = data && !loading && !error ? buildToc(data) : [];
+
   return (
-    <>
-      {toolbar}
-      {body}
-    </>
+    <div className={styles.layout}>
+      <div className={styles.content}>
+        {toolbar}
+        {body}
+      </div>
+      {sections.length > 0 && <SchemaToc sections={sections} />}
+    </div>
   );
 }
 

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -299,7 +299,15 @@ function Field({
 function FieldList({ schema, level }: { schema: JSONSchema; level: number }) {
   const properties = schema.properties ?? {};
   const required = new Set(schema.required ?? []);
-  const entries = Object.entries(properties).sort(([a], [b]) => a.localeCompare(b));
+  // Required fields first, then optional; alphabetical within each group.
+  const entries = Object.entries(properties).sort(([a], [b]) => {
+    const ra = required.has(a);
+    const rb = required.has(b);
+    if (ra !== rb) {
+      return ra ? -1 : 1;
+    }
+    return a.localeCompare(b);
+  });
 
   if (entries.length === 0) {
     return (
@@ -325,6 +333,52 @@ function FieldList({ schema, level }: { schema: JSONSchema; level: number }) {
   );
 }
 
+type VersionOption = { value: string; label: string };
+
+// The branch that carries schemas/ today. Kept as an explicit, default option
+// so the reference renders before any tagged release ships the schemas (no
+// release tag has schemas/ until nebari-infrastructure-core#362 lands). Once it
+// does, the release tags fetched below become selectable and this preview entry
+// can be dropped.
+const PREVIEW_OPTION: VersionOption = {
+  value: DEFAULT_REF,
+  label: `${DEFAULT_REF} (preview)`,
+};
+
+// Fetch the upstream release tags so the reader can view the schema for a
+// specific NIC version. Non-fatal on failure - the preview option alone renders
+// the page.
+function useVersions(repo: string): VersionOption[] {
+  const [tags, setTags] = useState<VersionOption[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/${repo}/tags?per_page=100`,
+          { headers: { Accept: 'application/vnd.github+json' } },
+        );
+        if (!res.ok) {
+          return;
+        }
+        const json: { name: string }[] = await res.json();
+        if (!cancelled) {
+          setTags(json.map((t) => ({ value: t.name, label: t.name })));
+        }
+      } catch {
+        /* leave tags empty; the preview option is enough */
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  return [PREVIEW_OPTION, ...tags];
+}
+
 export default function NicSchemaLoader({
   repo = DEFAULT_REPO,
   ref = DEFAULT_REF,
@@ -332,48 +386,90 @@ export default function NicSchemaLoader({
   repo?: string;
   ref?: string;
 }): JSX.Element {
-  const { data, loading, error } = useNicSchemas(repo, ref);
+  const [selectedRef, setSelectedRef] = useState(ref);
+  const versions = useVersions(repo);
+  const { data, loading, error } = useNicSchemas(repo, selectedRef);
 
+  const selector = (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        marginBottom: '1rem',
+      }}
+    >
+      <label htmlFor="nic-schema-version">
+        <strong>NIC version</strong>
+      </label>
+      <select
+        id="nic-schema-version"
+        value={selectedRef}
+        onChange={(e) => setSelectedRef(e.target.value)}
+      >
+        {versions.map((v) => (
+          <option key={v.value} value={v.value}>
+            {v.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+
+  let body: React.ReactNode;
   if (loading) {
-    return <p>Loading configuration schema…</p>;
-  }
-  if (error) {
-    return (
+    body = <p>Loading configuration schema…</p>;
+  } else if (error) {
+    body = (
       <Admonition type="danger" title="Could not load the configuration schema">
         <p>{error}</p>
         <p>
-          The reference is generated from{' '}
+          No generated schema was found for <code>{selectedRef}</code>. Release
+          tags only carry a schema once{' '}
           <a
-            href={`https://github.com/${repo}/tree/${ref}/schemas`}
+            href={`https://github.com/${repo}/tree/${selectedRef}/schemas`}
             target="_blank"
             rel="noopener noreferrer"
           >
-            <code>{repo}</code> <code>schemas/</code>
-          </a>
-          .
+            <code>schemas/</code>
+          </a>{' '}
+          ships in that version; pick the preview entry to view the latest.
         </p>
       </Admonition>
     );
-  }
-  if (!data) {
-    return null;
+  } else if (!data) {
+    body = null;
+  } else {
+    body = (
+      <>
+        <Admonition type="info">
+          This reference is generated automatically from the{' '}
+          <a
+            href={`https://github.com/${repo}/tree/${selectedRef}/schemas`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            NIC configuration JSON Schema
+          </a>{' '}
+          (<code>{selectedRef}</code>). It cannot drift from the config the code
+          actually accepts.
+        </Admonition>
+        {renderSections(data)}
+      </>
+    );
   }
 
   return (
     <>
-      <Admonition type="info">
-        This reference is generated automatically from the{' '}
-        <a
-          href={`https://github.com/${repo}/tree/${ref}/schemas`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          NIC configuration JSON Schema
-        </a>{' '}
-        (currently tracking <code>{ref}</code>). It cannot drift from the config
-        the code actually accepts.
-      </Admonition>
+      {selector}
+      {body}
+    </>
+  );
+}
 
+function renderSections(data: LoadedSchemas): JSX.Element {
+  return (
+    <>
       <Heading as="h2" id="top-level">
         Top-level configuration
       </Heading>

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -53,7 +53,7 @@ type LoadedSchemas = {
 // (nebari-infrastructure-core#362) lands on a tagged release, the release tags
 // below become selectable; until then this preview entry tracks the branch.
 const DEFAULT_REPO = 'nebari-dev/nebari-infrastructure-core';
-const DEFAULT_REF = 'feat/config-schema-gen';
+const DEFAULT_REF = 'feat/config-schema-gen-v2';
 
 const schemasBase = (repo: string, ref: string) =>
   `https://raw.githubusercontent.com/${repo}/${ref}/schemas`;

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -1,6 +1,5 @@
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
-import Details from '@theme/Details';
 import Heading from '@theme/Heading';
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
@@ -249,7 +248,7 @@ function typeLabel(schema: JSONSchema): string {
   }
   const mapValue = mapValueSchema(schema);
   if (mapValue) {
-    return `map<${typeLabel(mapValue)}>`;
+    return `map<string, ${typeLabel(mapValue)}>`;
   }
   if (Array.isArray(schema.type)) {
     return schema.type.join(' | ');
@@ -350,100 +349,166 @@ function requiredHint(valueSchema: JSONSchema): string {
   return req.length ? ` — requires ${req.join(', ')}` : '';
 }
 
+const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+// A compact collapsible for object/array/map field bodies. Native <details> so
+// the caret and dashed toggle match the field-grid system (@theme/Details
+// renders a heavier admonition-style box).
+function NestedFields({
+  label,
+  schema,
+  path,
+  level,
+}: {
+  label: string;
+  schema: JSONSchema;
+  path: string[];
+  level: number;
+}) {
+  return (
+    <details className={styles.nestedDetails}>
+      <summary className={styles.nestedToggle}>
+        <span className={styles.caret}>▸</span>
+        <span>{label}</span>
+      </summary>
+      <div className={styles.nested}>
+        <FieldList schema={schema} path={path} level={level} nested />
+      </div>
+    </details>
+  );
+}
+
+// One field, rendered as a two-column grid row: the name on the left, its type,
+// modifiers, description and nested body on the right. `nested` is true only for
+// rows inside a <details> (deeper than a section's direct fields); it turns on
+// the dotted-path breadcrumb and suppresses the required/optional group labels.
 function Field({
   name,
   schema,
   required,
   path,
   level,
+  nested,
 }: {
   name: string;
   schema: JSONSchema;
   required: boolean;
   path: string[];
   level: number;
+  nested: boolean;
 }) {
   const fieldPath = [...path, name];
   const id = pathId(fieldPath);
-  const nestedObject = schema.type === 'object' && schema.properties;
-  const arrayItems = schema.type === 'array' && schema.items?.properties ? schema.items : null;
-  const mapValue = mapValueSchema(schema);
-  const mapOfObjects = mapValue && mapValue.properties ? mapValue : null;
   const headingLevel = Math.min(level, 6) as 2 | 3 | 4 | 5 | 6;
 
-  return (
-    <div className={`${styles.field} ${required ? styles.fieldRequired : ''}`}>
-      {fieldPath.length > 1 && (
-        <div className={styles.breadcrumb}>{fieldPath.join('.')}</div>
-      )}
-      <Heading as={`h${headingLevel}`} id={id}>
-        <span className={styles.name}>{name}</span>
-      </Heading>
+  const objProps = schema.properties ? Object.keys(schema.properties).length : 0;
+  const mapValue = mapValueSchema(schema);
+  const nestedObject = schema.type === 'object' && objProps > 0 ? schema : null;
+  const emptyObject = schema.type === 'object' && objProps === 0 && !mapValue;
+  const arrayItems = schema.type === 'array' && schema.items?.properties ? schema.items : null;
+  const mapOfObjects = mapValue && mapValue.properties ? mapValue : null;
 
-      <div className={styles.meta}>
-        <span className={styles.chip}>{typeLabel(schema)}</span>
-        <span className={`${styles.chip} ${required ? styles.chipRequired : styles.chipOptional}`}>
-          {required ? 'required' : 'optional'}
-        </span>
-        {schema.default !== undefined && (
-          <span className={styles.chip}>default: {JSON.stringify(schema.default)}</span>
+  // Top-level `cluster`/`dns` are opaque here (keyed by provider); point at the
+  // provider sections that render their fields rather than an empty toggle.
+  const providerRef =
+    path.length === 0 && name === 'cluster'
+      ? 'cluster-providers'
+      : path.length === 0 && name === 'dns'
+        ? 'dns-providers'
+        : null;
+
+  return (
+    <div className={`${styles.fieldRow} ${required ? styles.fieldRowRequired : ''}`}>
+      <div className={styles.nameCol}>
+        {nested && fieldPath.length > 1 && (
+          <div className={styles.breadcrumb}>{fieldPath.slice(0, -1).join('.')}.</div>
         )}
-        {schema.pattern && (
-          <span className={styles.chip} title="Value must match this regular expression">
-            pattern: {schema.pattern}
-          </span>
-        )}
+        <Heading as={`h${headingLevel}`} id={id} className={styles.fieldName}>
+          <code>{name}</code>
+        </Heading>
       </div>
 
-      {schema.enum && (
-        <div className={styles.enumList}>
-          {schema.enum.map((v) => (
-            <code key={String(v)}>{String(v)}</code>
-          ))}
+      <div className={styles.detailCol}>
+        <div className={styles.meta}>
+          <span className={styles.chip}>
+            {mapValue ? (
+              <>
+                map&lt;string, <span className={styles.accent}>{typeLabel(mapValue)}</span>&gt;
+              </>
+            ) : (
+              typeLabel(schema)
+            )}
+          </span>
+          {required && <span className={`${styles.chip} ${styles.chipRequired}`}>required</span>}
+          {emptyObject && <span className={`${styles.chip} ${styles.chipKeyed}`}>keyed by provider</span>}
+          {schema.default !== undefined && (
+            <span className={styles.metaTag}>
+              <span className={styles.k}>default</span>
+              <span className={styles.v}>{JSON.stringify(schema.default)}</span>
+            </span>
+          )}
+          {schema.pattern && (
+            <span className={styles.metaTag} title="Value must match this regular expression">
+              <span className={styles.k}>pattern</span>
+              <span className={styles.v}>{schema.pattern}</span>
+            </span>
+          )}
         </div>
-      )}
 
-      {schema.description && <FieldDescription description={schema.description} />}
-
-      {schema.examples && schema.examples.length > 0 && (
-        <CodeBlock language="yaml">
-          {schema.examples.map((e) => (typeof e === 'string' ? e : JSON.stringify(e))).join('\n')}
-        </CodeBlock>
-      )}
-
-      {mapOfObjects && (
-        <CodeBlock language="yaml">{yamlSkeleton(name, mapOfObjects, true)}</CodeBlock>
-      )}
-
-      {nestedObject && (
-        <Details summary={<summary>{`${name} fields (${Object.keys(schema.properties ?? {}).length})`}</summary>}>
-          <div className={styles.nested}>
-            <FieldList schema={schema} path={fieldPath} level={level + 1} />
+        {schema.enum && (
+          <div className={`${styles.meta} ${styles.metaEnum}`}>
+            <span className={styles.enumLabel}>one of</span>
+            {schema.enum.map((v) => (
+              <span key={String(v)} className={`${styles.chip} ${styles.chipEnum}`}>
+                {String(v)}
+              </span>
+            ))}
           </div>
-        </Details>
-      )}
-      {arrayItems && (
-        <Details
-          summary={
-            <summary>{`${name} item fields (${Object.keys(arrayItems.properties ?? {}).length})${requiredHint(arrayItems)}`}</summary>
-          }
-        >
-          <div className={styles.nested}>
-            <FieldList schema={arrayItems} path={fieldPath} level={level + 1} />
-          </div>
-        </Details>
-      )}
-      {mapOfObjects && (
-        <Details
-          summary={
-            <summary>{`${name} entry fields (${Object.keys(mapOfObjects.properties ?? {}).length})${requiredHint(mapOfObjects)}`}</summary>
-          }
-        >
-          <div className={styles.nested}>
-            <FieldList schema={mapOfObjects} path={fieldPath} level={level + 1} />
-          </div>
-        </Details>
-      )}
+        )}
+
+        {schema.description && <FieldDescription description={schema.description} />}
+
+        {emptyObject && providerRef && (
+          <p className={styles.description}>
+            Configured per provider. See <a href={`#${providerRef}`}>the provider section below</a>.
+          </p>
+        )}
+
+        {schema.examples && schema.examples.length > 0 && (
+          <CodeBlock language="yaml">
+            {schema.examples.map((e) => (typeof e === 'string' ? e : JSON.stringify(e))).join('\n')}
+          </CodeBlock>
+        )}
+
+        {mapOfObjects && (
+          <CodeBlock language="yaml">{yamlSkeleton(name, mapOfObjects, true)}</CodeBlock>
+        )}
+
+        {nestedObject && (
+          <NestedFields
+            label={plural(objProps, 'nested field')}
+            schema={nestedObject}
+            path={fieldPath}
+            level={level + 1}
+          />
+        )}
+        {arrayItems && (
+          <NestedFields
+            label={`${plural(Object.keys(arrayItems.properties ?? {}).length, 'item field')}${requiredHint(arrayItems)}`}
+            schema={arrayItems}
+            path={fieldPath}
+            level={level + 1}
+          />
+        )}
+        {mapOfObjects && (
+          <NestedFields
+            label={`${plural(Object.keys(mapOfObjects.properties ?? {}).length, 'entry field')}${requiredHint(mapOfObjects)}`}
+            schema={mapOfObjects}
+            path={fieldPath}
+            level={level + 1}
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -452,10 +517,12 @@ function FieldList({
   schema,
   path,
   level,
+  nested = false,
 }: {
   schema: JSONSchema;
   path: string[];
   level: number;
+  nested?: boolean;
 }) {
   const properties = schema.properties ?? {};
   const required = new Set(schema.required ?? []);
@@ -481,14 +548,26 @@ function FieldList({
       required={required.has(name)}
       path={path}
       level={level}
+      nested={nested}
     />
   );
 
+  // Group labels only mark a section's direct fields; nested rows are already
+  // scoped by their <details> toggle and left-border, so labelling them adds noise.
   return (
     <>
+      {!nested && requiredNames.length > 0 && (
+        <div className={`${styles.groupLabel} ${styles.groupLabelRequired}`}>
+          <span className={styles.tag}>Required</span>
+          <span className={styles.rule} />
+        </div>
+      )}
       {requiredNames.map(renderField)}
-      {requiredNames.length > 0 && optionalNames.length > 0 && (
-        <div className={styles.divider}>Optional fields</div>
+      {!nested && optionalNames.length > 0 && (
+        <div className={styles.groupLabel}>
+          <span className={styles.tag}>Optional</span>
+          <span className={styles.rule} />
+        </div>
       )}
       {optionalNames.map(renderField)}
     </>
@@ -609,8 +688,8 @@ export default function NicSchemaLoader({
 
   const toolbar = (
     <div className={styles.toolbar}>
-      <label htmlFor="nic-schema-version">
-        <strong>NIC version</strong>
+      <label className={styles.toolbarLabel} htmlFor="nic-schema-version">
+        NIC version
       </label>
       <select
         id="nic-schema-version"
@@ -624,12 +703,13 @@ export default function NicSchemaLoader({
         ))}
       </select>
       {isPreview && <span className={styles.previewBadge}>unreleased</span>}
+      <span className={styles.toolbarSpacer} />
       <a
         href={`https://github.com/${repo}/tree/${selectedRef}/schemas`}
         target="_blank"
         rel="noopener noreferrer"
       >
-        source
+        source ↗
       </a>
     </div>
   );
@@ -667,20 +747,44 @@ export default function NicSchemaLoader({
   );
 }
 
+function SectionHead({
+  id,
+  title,
+  meta,
+}: {
+  id: string;
+  title: string;
+  meta: string;
+}) {
+  return (
+    <div className={styles.sectionHead}>
+      <Heading as="h2" id={id}>
+        {title}
+      </Heading>
+      <span className={styles.sectionMeta}>{meta}</span>
+    </div>
+  );
+}
+
 function renderSections(data: LoadedSchemas): JSX.Element {
+  const tlNames = Object.keys(data.topLevel.properties ?? {});
+  const tlRequired = (data.topLevel.required ?? []).length;
+
   return (
     <>
-      <Heading as="h2" id="top-level">
-        Top-level configuration
-      </Heading>
-      <FieldList schema={data.topLevel} path={[]} level={3} />
+      <section className={styles.section}>
+        <SectionHead
+          id="top-level"
+          title="Top-level configuration"
+          meta={`${plural(tlNames.length, 'field')} · ${tlRequired} required`}
+        />
+        <FieldList schema={data.topLevel} path={[]} level={3} />
+      </section>
 
       {data.cluster.length > 0 && (
-        <>
-          <Heading as="h2" id="cluster-providers">
-            Cluster providers
-          </Heading>
-          <p>
+        <section className={styles.section}>
+          <SectionHead id="cluster-providers" title="Cluster providers" meta="exactly one applies" />
+          <p className={styles.sectionIntro}>
             Configured under <code>cluster.&lt;provider&gt;</code>. Exactly one
             provider is set per deployment.
           </p>
@@ -691,15 +795,13 @@ function renderSections(data: LoadedSchemas): JSX.Element {
               </TabItem>
             ))}
           </Tabs>
-        </>
+        </section>
       )}
 
       {data.dns.length > 0 && (
-        <>
-          <Heading as="h2" id="dns-providers">
-            DNS providers
-          </Heading>
-          <p>
+        <section className={styles.section}>
+          <SectionHead id="dns-providers" title="DNS providers" meta="exactly one applies" />
+          <p className={styles.sectionIntro}>
             Configured under <code>dns.&lt;provider&gt;</code>. Credentials (API
             tokens) are read from environment variables, not from config.
           </p>
@@ -710,7 +812,7 @@ function renderSections(data: LoadedSchemas): JSX.Element {
               </TabItem>
             ))}
           </Tabs>
-        </>
+        </section>
       )}
     </>
   );

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -378,10 +378,63 @@ function NestedFields({
   );
 }
 
-// One field, rendered as a two-column grid row: the name on the left, its type,
-// modifiers, description and nested body on the right. `nested` is true only for
-// rows inside a <details> (deeper than a section's direct fields); it turns on
-// the dotted-path breadcrumb and suppresses the required/optional group labels.
+// Type / required / keyed / default / pattern / enum, all inline on the field
+// name's line. Shared between top-level rows (flex) and nested rows (inline).
+function MetaChips({
+  schema,
+  required,
+  emptyObject,
+  mapValue,
+}: {
+  schema: JSONSchema;
+  required: boolean;
+  emptyObject: boolean;
+  mapValue: JSONSchema | null;
+}) {
+  return (
+    <>
+      <span className={styles.chip}>
+        {mapValue ? (
+          <>
+            map&lt;string, <span className={styles.accent}>{typeLabel(mapValue)}</span>&gt;
+          </>
+        ) : (
+          typeLabel(schema)
+        )}
+      </span>
+      {required && <span className={`${styles.chip} ${styles.chipRequired}`}>required</span>}
+      {emptyObject && <span className={`${styles.chip} ${styles.chipKeyed}`}>keyed by provider</span>}
+      {schema.default !== undefined && (
+        <span className={styles.metaTag}>
+          <span className={styles.k}>default</span>
+          <span className={styles.v}>{JSON.stringify(schema.default)}</span>
+        </span>
+      )}
+      {schema.pattern && (
+        <span className={styles.metaTag} title="Value must match this regular expression">
+          <span className={styles.k}>pattern</span>
+          <span className={styles.v}>{schema.pattern}</span>
+        </span>
+      )}
+      {schema.enum && (
+        <>
+          <span className={styles.enumLabel}>one of</span>
+          {schema.enum.map((v) => (
+            <span key={String(v)} className={`${styles.chip} ${styles.chipEnum}`}>
+              {String(v)}
+            </span>
+          ))}
+        </>
+      )}
+    </>
+  );
+}
+
+// One field. The name and its inline metadata sit on one line; descriptions,
+// YAML snippets and nested blocks stack below. `nested` is true only for rows
+// inside a <details> (deeper than a section's direct fields): those show their
+// full dotted path as a hover tooltip (not a breadcrumb line), drop the row
+// hairline, and suppress the required/optional group labels.
 function Field({
   name,
   schema,
@@ -417,98 +470,80 @@ function Field({
         ? 'dns-providers'
         : null;
 
+  const below = (
+    <>
+      {schema.description && <FieldDescription description={schema.description} />}
+      {emptyObject && providerRef && (
+        <p className={styles.description}>
+          Configured per provider. See <a href={`#${providerRef}`}>the provider section below</a>.
+        </p>
+      )}
+      {schema.examples && schema.examples.length > 0 && (
+        <CodeBlock language="yaml">
+          {schema.examples.map((e) => (typeof e === 'string' ? e : JSON.stringify(e))).join('\n')}
+        </CodeBlock>
+      )}
+      {mapOfObjects && (
+        <CodeBlock language="yaml">{yamlSkeleton(name, mapOfObjects, true)}</CodeBlock>
+      )}
+      {nestedObject && (
+        <NestedFields
+          label={plural(objProps, 'nested field')}
+          schema={nestedObject}
+          path={fieldPath}
+          level={level + 1}
+        />
+      )}
+      {arrayItems && (
+        <NestedFields
+          label={`${plural(Object.keys(arrayItems.properties ?? {}).length, 'item field')}${requiredHint(arrayItems)}`}
+          schema={arrayItems}
+          path={fieldPath}
+          level={level + 1}
+        />
+      )}
+      {mapOfObjects && (
+        <NestedFields
+          label={`${plural(Object.keys(mapOfObjects.properties ?? {}).length, 'entry field')}${requiredHint(mapOfObjects)}`}
+          schema={mapOfObjects}
+          path={fieldPath}
+          level={level + 1}
+        />
+      )}
+    </>
+  );
+
+  const chips = (
+    <MetaChips schema={schema} required={required} emptyObject={emptyObject} mapValue={mapValue} />
+  );
+
+  if (nested) {
+    return (
+      <div className={`${styles.fieldRowNested} ${required ? styles.fieldRowNestedRequired : ''}`}>
+        <code id={id} title={fieldPath.join('.')} className={styles.fieldNameNested}>
+          {name}
+        </code>
+        <span className={styles.metaInline}>{chips}</span>
+        {below}
+      </div>
+    );
+  }
+
+  const hasBelow =
+    !!schema.description ||
+    (emptyObject && !!providerRef) ||
+    (!!schema.examples && schema.examples.length > 0) ||
+    !!nestedObject ||
+    !!arrayItems ||
+    !!mapOfObjects;
+
   return (
     <div className={`${styles.fieldRow} ${required ? styles.fieldRowRequired : ''}`}>
-      <div className={styles.nameCol}>
-        {nested && fieldPath.length > 1 && (
-          <div className={styles.breadcrumb}>{fieldPath.slice(0, -1).join('.')}.</div>
-        )}
-        <Heading as={`h${headingLevel}`} id={id} className={styles.fieldName}>
-          <code>{name}</code>
-        </Heading>
-      </div>
-
-      <div className={styles.detailCol}>
-        <div className={styles.meta}>
-          <span className={styles.chip}>
-            {mapValue ? (
-              <>
-                map&lt;string, <span className={styles.accent}>{typeLabel(mapValue)}</span>&gt;
-              </>
-            ) : (
-              typeLabel(schema)
-            )}
-          </span>
-          {required && <span className={`${styles.chip} ${styles.chipRequired}`}>required</span>}
-          {emptyObject && <span className={`${styles.chip} ${styles.chipKeyed}`}>keyed by provider</span>}
-          {schema.default !== undefined && (
-            <span className={styles.metaTag}>
-              <span className={styles.k}>default</span>
-              <span className={styles.v}>{JSON.stringify(schema.default)}</span>
-            </span>
-          )}
-          {schema.pattern && (
-            <span className={styles.metaTag} title="Value must match this regular expression">
-              <span className={styles.k}>pattern</span>
-              <span className={styles.v}>{schema.pattern}</span>
-            </span>
-          )}
-        </div>
-
-        {schema.enum && (
-          <div className={`${styles.meta} ${styles.metaEnum}`}>
-            <span className={styles.enumLabel}>one of</span>
-            {schema.enum.map((v) => (
-              <span key={String(v)} className={`${styles.chip} ${styles.chipEnum}`}>
-                {String(v)}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {schema.description && <FieldDescription description={schema.description} />}
-
-        {emptyObject && providerRef && (
-          <p className={styles.description}>
-            Configured per provider. See <a href={`#${providerRef}`}>the provider section below</a>.
-          </p>
-        )}
-
-        {schema.examples && schema.examples.length > 0 && (
-          <CodeBlock language="yaml">
-            {schema.examples.map((e) => (typeof e === 'string' ? e : JSON.stringify(e))).join('\n')}
-          </CodeBlock>
-        )}
-
-        {mapOfObjects && (
-          <CodeBlock language="yaml">{yamlSkeleton(name, mapOfObjects, true)}</CodeBlock>
-        )}
-
-        {nestedObject && (
-          <NestedFields
-            label={plural(objProps, 'nested field')}
-            schema={nestedObject}
-            path={fieldPath}
-            level={level + 1}
-          />
-        )}
-        {arrayItems && (
-          <NestedFields
-            label={`${plural(Object.keys(arrayItems.properties ?? {}).length, 'item field')}${requiredHint(arrayItems)}`}
-            schema={arrayItems}
-            path={fieldPath}
-            level={level + 1}
-          />
-        )}
-        {mapOfObjects && (
-          <NestedFields
-            label={`${plural(Object.keys(mapOfObjects.properties ?? {}).length, 'entry field')}${requiredHint(mapOfObjects)}`}
-            schema={mapOfObjects}
-            path={fieldPath}
-            level={level + 1}
-          />
-        )}
-      </div>
+      <Heading as={`h${headingLevel}`} id={id} className={styles.fieldName}>
+        <code>{name}</code>
+      </Heading>
+      <span className={styles.meta}>{chips}</span>
+      {hasBelow && <div className={styles.below}>{below}</div>}
     </div>
   );
 }
@@ -559,14 +594,12 @@ function FieldList({
       {!nested && requiredNames.length > 0 && (
         <div className={`${styles.groupLabel} ${styles.groupLabelRequired}`}>
           <span className={styles.tag}>Required</span>
-          <span className={styles.rule} />
         </div>
       )}
       {requiredNames.map(renderField)}
       {!nested && optionalNames.length > 0 && (
         <div className={styles.groupLabel}>
           <span className={styles.tag}>Optional</span>
-          <span className={styles.rule} />
         </div>
       )}
       {optionalNames.map(renderField)}

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -1,4 +1,5 @@
 import Admonition from '@theme/Admonition';
+import CodeBlock from '@theme/CodeBlock';
 import Details from '@theme/Details';
 import Heading from '@theme/Heading';
 import TabItem from '@theme/TabItem';
@@ -7,12 +8,14 @@ import React, { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import styles from './styles.module.css';
+
 /**
  * NicSchemaLoader renders the Nebari Infrastructure Core (NIC) configuration
  * reference directly from the JSON Schema that `nebari-infrastructure-core`
- * generates from its Go config structs (the `schemas/` directory produced by
- * `make schemas`). Because the schema is generated from the source of truth,
- * this page cannot drift from the actual config contract.
+ * generates from its Go config structs (`schemas/`, produced by `make
+ * schemas`). Because the schema is generated from the source of truth, this
+ * page cannot drift from the config the CLI actually accepts.
  *
  * Producer contract (schemas/manifest.json):
  *   { "providers": [...], "dns": [...], "top_level": "nebari-config.json" }
@@ -29,6 +32,7 @@ type JSONSchema = {
   items?: JSONSchema;
   enum?: unknown[];
   default?: unknown;
+  examples?: unknown[];
   pattern?: string;
   additionalProperties?: boolean | JSONSchema;
   $ref?: string;
@@ -47,25 +51,26 @@ type LoadedSchemas = {
 };
 
 // Source of truth. Once the schema-generation pipeline
-// (nebari-infrastructure-core#362) lands on a tagged release, pin `ref` to
-// that tag for versioned docs; until then it tracks the feature branch.
+// (nebari-infrastructure-core#362) lands on a tagged release, the release tags
+// below become selectable; until then this preview entry tracks the branch.
 const DEFAULT_REPO = 'nebari-dev/nebari-infrastructure-core';
 const DEFAULT_REF = 'feat/config-schema-gen';
 
 const schemasBase = (repo: string, ref: string) =>
   `https://raw.githubusercontent.com/${repo}/${ref}/schemas`;
 
-const slug = (name: string) => name.replace(/_/g, '-').toLowerCase();
+const slug = (name: string) => name.replace(/[_.]/g, '-').toLowerCase();
+
+// Field id from the full config path, so ids are unique across providers
+// (a bare `enabled` occurs in five different `$defs`).
+const pathId = (path: string[]) => path.map(slug).join('-');
 
 const refKey = (ref: string) => ref.replace('#/$defs/', '');
 
 /**
  * Inline every internal `#/$defs/...` reference against the file's own `$defs`
- * map. The generated schemas only ever use same-file pointer refs, so a local
- * dereference is sufficient - and necessary, because generic `$ref` resolvers
- * leave these recursive `$defs` refs untouched. `seen` guards against cycles
- * (a Go type that transitively references itself), returning a plain object
- * stub instead of recursing forever.
+ * map. The generated schemas use recursive same-file pointer refs that generic
+ * `$ref` resolvers leave untouched. `seen` guards against cycles.
  */
 function deref(
   node: JSONSchema,
@@ -84,8 +89,6 @@ function deref(
       return { type: 'object', description: node.description };
     }
     const target = deref(defs[key], defs, new Set(seen).add(key));
-    // Preserve a description written on the ref site (invopop puts the field
-    // doc there) unless the target already carries its own.
     return node.description && !target.description
       ? { ...target, description: node.description }
       : target;
@@ -100,10 +103,6 @@ function deref(
   return out as JSONSchema;
 }
 
-/**
- * Fetch one schema file and return the object its top-level `$ref` points to,
- * with every nested `$ref` inlined. Provider schemas are self-contained.
- */
 async function loadSchemaFile(base: string, path: string): Promise<JSONSchema> {
   const res = await fetch(`${base}/${path}`, {
     headers: { Accept: 'application/json' },
@@ -126,6 +125,8 @@ function useNicSchemas(repo: string, ref: string) {
   useEffect(() => {
     let cancelled = false;
     const base = schemasBase(repo, ref);
+    setLoading(true);
+    setError(null);
 
     async function load() {
       try {
@@ -157,13 +158,11 @@ function useNicSchemas(repo: string, ref: string) {
 
         if (!cancelled) {
           setData({ topLevel, cluster, dns });
+          setLoading(false);
         }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
-        }
-      } finally {
-        if (!cancelled) {
           setLoading(false);
         }
       }
@@ -178,8 +177,51 @@ function useNicSchemas(repo: string, ref: string) {
   return { data, loading, error };
 }
 
-// A map type is a JSON-Schema object with no fixed properties whose value shape
-// is given by an `additionalProperties` schema (e.g. Go `map[string]NodeGroup`).
+type VersionOption = { value: string; label: string };
+
+const PREVIEW_OPTION: VersionOption = {
+  value: DEFAULT_REF,
+  label: `${DEFAULT_REF} (preview)`,
+};
+
+// Fetch upstream release tags so a reader can view the schema for a specific
+// NIC version. Non-fatal on failure - the preview option alone renders the
+// page. (Follow-up: replace with a committed schema-versions.json published by
+// the NIC release workflow, so the toggle only lists versions that actually
+// ship schemas/.)
+function useVersions(repo: string): VersionOption[] {
+  const [tags, setTags] = useState<VersionOption[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/${repo}/tags?per_page=100`,
+          { headers: { Accept: 'application/vnd.github+json' } },
+        );
+        if (!res.ok) {
+          return;
+        }
+        const json: { name: string }[] = await res.json();
+        if (!cancelled) {
+          setTags(json.map((t) => ({ value: t.name, label: t.name })));
+        }
+      } catch {
+        /* leave tags empty; the preview option is enough */
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  return [PREVIEW_OPTION, ...tags];
+}
+
+// A map type is an object with no fixed properties whose value shape is an
+// `additionalProperties` schema (Go `map[string]T`).
 function mapValueSchema(schema: JSONSchema): JSONSchema | null {
   if (
     schema.type === 'object' &&
@@ -215,101 +257,211 @@ function typeLabel(schema: JSONSchema): string {
   return schema.type ?? (schema.properties ? 'object' : 'any');
 }
 
-function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <tr>
-      <th style={{ textAlign: 'left', padding: '6px 12px', whiteSpace: 'nowrap' }}>
-        {label}
-      </th>
-      <td style={{ padding: '6px 12px', width: '100%' }}>{value}</td>
-    </tr>
+// invopop emits godoc verbatim, which repeats the field name in Go casing
+// ("Email is the email address..."). Strip that lead-in so the description
+// reads as prose. Purely cosmetic; leaves the description intact if it does not
+// match the pattern.
+function cleanDescription(desc: string): string {
+  const stripped = desc.replace(
+    /^[A-Z][A-Za-z0-9]* (is|are|holds|controls|specifies|represents|configures|defines|sets|enables|contains|determines|provides|indicates) /,
+    '',
   );
+  if (stripped === desc) {
+    return desc;
+  }
+  return stripped.charAt(0).toUpperCase() + stripped.slice(1);
+}
+
+// Turn `owner/repo#N` references (which sometimes leak from internal godoc)
+// into links rather than rendering bare implementation noise.
+const issueRefLink = {
+  text: ({ children }: { children: React.ReactNode }) => {
+    const parts = React.Children.toArray(children).map((child) => {
+      if (typeof child !== 'string') {
+        return child;
+      }
+      return child.split(/(\b[\w-]+\/[\w.-]+#\d+\b)/g).map((seg, i) => {
+        const m = seg.match(/^([\w-]+\/[\w.-]+)#(\d+)$/);
+        return m ? (
+          // eslint-disable-next-line react/no-array-index-key
+          <a key={i} href={`https://github.com/${m[1]}/issues/${m[2]}`}>
+            {seg}
+          </a>
+        ) : (
+          seg
+        );
+      });
+    });
+    return <>{parts}</>;
+  },
+};
+
+function FieldDescription({ description }: { description: string }) {
+  return (
+    <div className={styles.description}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={issueRefLink}>
+        {cleanDescription(description)}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+// A minimal YAML skeleton for a map/object field: keys are the required fields
+// plus the first couple of optionals. Derived mechanically from the schema; far
+// clearer than prose for shapes like `node_groups`.
+function yamlSkeleton(name: string, valueSchema: JSONSchema, isMap: boolean): string {
+  const props = valueSchema.properties ?? {};
+  const required = new Set(valueSchema.required ?? []);
+  const keys = Object.keys(props).sort((a, b) => {
+    const ra = required.has(a);
+    const rb = required.has(b);
+    if (ra !== rb) {
+      return ra ? -1 : 1;
+    }
+    return 0;
+  });
+  const shown = keys.filter((k) => required.has(k));
+  for (const k of keys) {
+    if (shown.length >= 3) {
+      break;
+    }
+    if (!shown.includes(k)) {
+      shown.push(k);
+    }
+  }
+  const placeholder = (s: JSONSchema) => {
+    const t = Array.isArray(s.type) ? s.type[0] : s.type;
+    if (t === 'boolean') return 'true';
+    if (t === 'integer' || t === 'number') return '0';
+    if (t === 'array') return '[]';
+    return `<${typeLabel(s)}>`;
+  };
+  const body = shown.map(
+    (k) => `    ${k}: ${placeholder(props[k])}${required.has(k) ? '   # required' : ''}`,
+  );
+  if (isMap) {
+    return `${name}:\n  <name>:\n${body.join('\n')}`;
+  }
+  return `${name}:\n${body.map((l) => l.slice(2)).join('\n')}`;
+}
+
+function requiredHint(valueSchema: JSONSchema): string {
+  const req = valueSchema.required ?? [];
+  return req.length ? ` — requires ${req.join(', ')}` : '';
 }
 
 function Field({
   name,
   schema,
   required,
+  path,
   level,
 }: {
   name: string;
   schema: JSONSchema;
   required: boolean;
+  path: string[];
   level: number;
 }) {
+  const fieldPath = [...path, name];
+  const id = pathId(fieldPath);
   const nestedObject = schema.type === 'object' && schema.properties;
-  const arrayOfObjects = schema.type === 'array' && schema.items?.properties;
+  const arrayItems = schema.type === 'array' && schema.items?.properties ? schema.items : null;
   const mapValue = mapValueSchema(schema);
-  const mapOfObjects = mapValue && mapValue.properties;
+  const mapOfObjects = mapValue && mapValue.properties ? mapValue : null;
   const headingLevel = Math.min(level, 6) as 2 | 3 | 4 | 5 | 6;
 
   return (
-    <div style={{ marginBottom: '18px' }}>
-      <Heading as={`h${headingLevel}`} id={slug(name)}>
-        <code>{name}</code>{' '}
-        {required && <span className="badge badge--secondary">required</span>}
+    <div className={`${styles.field} ${required ? styles.fieldRequired : ''}`}>
+      {fieldPath.length > 1 && (
+        <div className={styles.breadcrumb}>{fieldPath.join('.')}</div>
+      )}
+      <Heading as={`h${headingLevel}`} id={id}>
+        <span className={styles.name}>{name}</span>
       </Heading>
 
-      {schema.description && (
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-          {schema.description}
-        </ReactMarkdown>
+      <div className={styles.meta}>
+        <span className={styles.chip}>{typeLabel(schema)}</span>
+        <span className={`${styles.chip} ${required ? styles.chipRequired : styles.chipOptional}`}>
+          {required ? 'required' : 'optional'}
+        </span>
+        {schema.default !== undefined && (
+          <span className={styles.chip}>default: {JSON.stringify(schema.default)}</span>
+        )}
+        {schema.pattern && (
+          <span className={styles.chip} title="Value must match this regular expression">
+            pattern: {schema.pattern}
+          </span>
+        )}
+      </div>
+
+      {schema.enum && (
+        <div className={styles.enumList}>
+          {schema.enum.map((v) => (
+            <code key={String(v)}>{String(v)}</code>
+          ))}
+        </div>
       )}
 
-      <table style={{ borderCollapse: 'collapse', display: 'table' }}>
-        <tbody>
-          <DetailRow label="Type" value={<code>{typeLabel(schema)}</code>} />
-          {schema.enum && (
-            <DetailRow
-              label="Options"
-              value={<code>{schema.enum.map(String).join(', ')}</code>}
-            />
-          )}
-          {schema.pattern && (
-            <DetailRow label="Pattern" value={<code>{schema.pattern}</code>} />
-          )}
-          {schema.default !== undefined && (
-            <DetailRow
-              label="Default"
-              value={<code>{JSON.stringify(schema.default)}</code>}
-            />
-          )}
-        </tbody>
-      </table>
+      {schema.description && <FieldDescription description={schema.description} />}
+
+      {schema.examples && schema.examples.length > 0 && (
+        <CodeBlock language="yaml">
+          {schema.examples.map((e) => (typeof e === 'string' ? e : JSON.stringify(e))).join('\n')}
+        </CodeBlock>
+      )}
+
+      {mapOfObjects && (
+        <CodeBlock language="yaml">{yamlSkeleton(name, mapOfObjects, true)}</CodeBlock>
+      )}
 
       {nestedObject && (
-        <Details summary={<summary>Nested fields</summary>}>
-          <FieldList schema={schema} level={level + 1} />
+        <Details summary={<summary>{`${name} fields (${Object.keys(schema.properties ?? {}).length})`}</summary>}>
+          <div className={styles.nested}>
+            <FieldList schema={schema} path={fieldPath} level={level + 1} />
+          </div>
         </Details>
       )}
-      {arrayOfObjects && (
-        <Details summary={<summary>Item fields</summary>}>
-          <FieldList schema={schema.items as JSONSchema} level={level + 1} />
+      {arrayItems && (
+        <Details
+          summary={
+            <summary>{`${name} item fields (${Object.keys(arrayItems.properties ?? {}).length})${requiredHint(arrayItems)}`}</summary>
+          }
+        >
+          <div className={styles.nested}>
+            <FieldList schema={arrayItems} path={fieldPath} level={level + 1} />
+          </div>
         </Details>
       )}
       {mapOfObjects && (
-        <Details summary={<summary>Value fields (one entry per key)</summary>}>
-          <FieldList schema={mapValue as JSONSchema} level={level + 1} />
+        <Details
+          summary={
+            <summary>{`${name} entry fields (${Object.keys(mapOfObjects.properties ?? {}).length})${requiredHint(mapOfObjects)}`}</summary>
+          }
+        >
+          <div className={styles.nested}>
+            <FieldList schema={mapOfObjects} path={fieldPath} level={level + 1} />
+          </div>
         </Details>
       )}
     </div>
   );
 }
 
-function FieldList({ schema, level }: { schema: JSONSchema; level: number }) {
+function FieldList({
+  schema,
+  path,
+  level,
+}: {
+  schema: JSONSchema;
+  path: string[];
+  level: number;
+}) {
   const properties = schema.properties ?? {};
   const required = new Set(schema.required ?? []);
-  // Required fields first, then optional; alphabetical within each group.
-  const entries = Object.entries(properties).sort(([a], [b]) => {
-    const ra = required.has(a);
-    const rb = required.has(b);
-    if (ra !== rb) {
-      return ra ? -1 : 1;
-    }
-    return a.localeCompare(b);
-  });
+  const names = Object.keys(properties);
 
-  if (entries.length === 0) {
+  if (names.length === 0) {
     return (
       <Admonition type="note">
         This section is keyed by provider name; see the provider-specific
@@ -318,65 +470,29 @@ function FieldList({ schema, level }: { schema: JSONSchema; level: number }) {
     );
   }
 
+  const requiredNames = names.filter((n) => required.has(n)).sort();
+  const optionalNames = names.filter((n) => !required.has(n)).sort();
+
+  const renderField = (name: string) => (
+    <Field
+      key={name}
+      name={name}
+      schema={properties[name]}
+      required={required.has(name)}
+      path={path}
+      level={level}
+    />
+  );
+
   return (
     <>
-      {entries.map(([key, value]) => (
-        <Field
-          key={key}
-          name={key}
-          schema={value}
-          required={required.has(key)}
-          level={level}
-        />
-      ))}
+      {requiredNames.map(renderField)}
+      {requiredNames.length > 0 && optionalNames.length > 0 && (
+        <div className={styles.divider}>Optional fields</div>
+      )}
+      {optionalNames.map(renderField)}
     </>
   );
-}
-
-type VersionOption = { value: string; label: string };
-
-// The branch that carries schemas/ today. Kept as an explicit, default option
-// so the reference renders before any tagged release ships the schemas (no
-// release tag has schemas/ until nebari-infrastructure-core#362 lands). Once it
-// does, the release tags fetched below become selectable and this preview entry
-// can be dropped.
-const PREVIEW_OPTION: VersionOption = {
-  value: DEFAULT_REF,
-  label: `${DEFAULT_REF} (preview)`,
-};
-
-// Fetch the upstream release tags so the reader can view the schema for a
-// specific NIC version. Non-fatal on failure - the preview option alone renders
-// the page.
-function useVersions(repo: string): VersionOption[] {
-  const [tags, setTags] = useState<VersionOption[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      try {
-        const res = await fetch(
-          `https://api.github.com/repos/${repo}/tags?per_page=100`,
-          { headers: { Accept: 'application/vnd.github+json' } },
-        );
-        if (!res.ok) {
-          return;
-        }
-        const json: { name: string }[] = await res.json();
-        if (!cancelled) {
-          setTags(json.map((t) => ({ value: t.name, label: t.name })));
-        }
-      } catch {
-        /* leave tags empty; the preview option is enough */
-      }
-    }
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [repo]);
-
-  return [PREVIEW_OPTION, ...tags];
 }
 
 export default function NicSchemaLoader({
@@ -389,16 +505,10 @@ export default function NicSchemaLoader({
   const [selectedRef, setSelectedRef] = useState(ref);
   const versions = useVersions(repo);
   const { data, loading, error } = useNicSchemas(repo, selectedRef);
+  const isPreview = selectedRef === DEFAULT_REF;
 
-  const selector = (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '0.5rem',
-        marginBottom: '1rem',
-      }}
-    >
+  const toolbar = (
+    <div className={styles.toolbar}>
       <label htmlFor="nic-schema-version">
         <strong>NIC version</strong>
       </label>
@@ -413,6 +523,14 @@ export default function NicSchemaLoader({
           </option>
         ))}
       </select>
+      {isPreview && <span className={styles.previewBadge}>unreleased</span>}
+      <a
+        href={`https://github.com/${repo}/tree/${selectedRef}/schemas`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        source
+      </a>
     </div>
   );
 
@@ -425,43 +543,20 @@ export default function NicSchemaLoader({
         <p>{error}</p>
         <p>
           No generated schema was found for <code>{selectedRef}</code>. Release
-          tags only carry a schema once{' '}
-          <a
-            href={`https://github.com/${repo}/tree/${selectedRef}/schemas`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <code>schemas/</code>
-          </a>{' '}
-          ships in that version; pick the preview entry to view the latest.
+          tags only carry a schema once <code>schemas/</code> ships in that
+          version; pick the preview entry to view the latest.
         </p>
       </Admonition>
     );
   } else if (!data) {
     body = null;
   } else {
-    body = (
-      <>
-        <Admonition type="info">
-          This reference is generated automatically from the{' '}
-          <a
-            href={`https://github.com/${repo}/tree/${selectedRef}/schemas`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            NIC configuration JSON Schema
-          </a>{' '}
-          (<code>{selectedRef}</code>). It cannot drift from the config the code
-          actually accepts.
-        </Admonition>
-        {renderSections(data)}
-      </>
-    );
+    body = renderSections(data);
   }
 
   return (
     <>
-      {selector}
+      {toolbar}
       {body}
     </>
   );
@@ -473,7 +568,7 @@ function renderSections(data: LoadedSchemas): JSX.Element {
       <Heading as="h2" id="top-level">
         Top-level configuration
       </Heading>
-      <FieldList schema={data.topLevel} level={3} />
+      <FieldList schema={data.topLevel} path={[]} level={3} />
 
       {data.cluster.length > 0 && (
         <>
@@ -484,10 +579,10 @@ function renderSections(data: LoadedSchemas): JSX.Element {
             Configured under <code>cluster.&lt;provider&gt;</code>. Exactly one
             provider is set per deployment.
           </p>
-          <Tabs>
+          <Tabs queryString="cluster-provider">
             {data.cluster.map(({ name, schema }) => (
               <TabItem key={name} value={name} label={name}>
-                <FieldList schema={schema} level={3} />
+                <FieldList schema={schema} path={['cluster', name]} level={3} />
               </TabItem>
             ))}
           </Tabs>
@@ -503,10 +598,10 @@ function renderSections(data: LoadedSchemas): JSX.Element {
             Configured under <code>dns.&lt;provider&gt;</code>. Credentials (API
             tokens) are read from environment variables, not from config.
           </p>
-          <Tabs>
+          <Tabs queryString="dns-provider">
             {data.dns.map(({ name, schema }) => (
               <TabItem key={name} value={name} label={name}>
-                <FieldList schema={schema} level={3} />
+                <FieldList schema={schema} path={['dns', name]} level={3} />
               </TabItem>
             ))}
           </Tabs>

--- a/docs/src/components/NicSchemaLoader/index.tsx
+++ b/docs/src/components/NicSchemaLoader/index.tsx
@@ -256,92 +256,14 @@ function typeLabel(schema: JSONSchema): string {
   return schema.type ?? (schema.properties ? 'object' : 'any');
 }
 
-// invopop emits godoc verbatim, which repeats the field name in Go casing
-// ("Email is the email address..."). Strip that lead-in so the description
-// reads as prose. Purely cosmetic; leaves the description intact if it does not
-// match the pattern.
-function cleanDescription(desc: string): string {
-  const stripped = desc.replace(
-    /^[A-Z][A-Za-z0-9]* (is|are|holds|controls|specifies|represents|configures|defines|sets|enables|contains|determines|provides|indicates) /,
-    '',
-  );
-  if (stripped === desc) {
-    return desc;
-  }
-  return stripped.charAt(0).toUpperCase() + stripped.slice(1);
-}
-
-// Turn `owner/repo#N` references (which sometimes leak from internal godoc)
-// into links rather than rendering bare implementation noise.
-const issueRefLink = {
-  text: ({ children }: { children: React.ReactNode }) => {
-    const parts = React.Children.toArray(children).map((child) => {
-      if (typeof child !== 'string') {
-        return child;
-      }
-      return child.split(/(\b[\w-]+\/[\w.-]+#\d+\b)/g).map((seg, i) => {
-        const m = seg.match(/^([\w-]+\/[\w.-]+)#(\d+)$/);
-        return m ? (
-          // eslint-disable-next-line react/no-array-index-key
-          <a key={i} href={`https://github.com/${m[1]}/issues/${m[2]}`}>
-            {seg}
-          </a>
-        ) : (
-          seg
-        );
-      });
-    });
-    return <>{parts}</>;
-  },
-};
-
+// Render the schema's description verbatim as markdown. No rewriting or
+// stripping: the page shows exactly what the schema carries.
 function FieldDescription({ description }: { description: string }) {
   return (
     <div className={styles.description}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={issueRefLink}>
-        {cleanDescription(description)}
-      </ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{description}</ReactMarkdown>
     </div>
   );
-}
-
-// A minimal YAML skeleton for a map/object field: keys are the required fields
-// plus the first couple of optionals. Derived mechanically from the schema; far
-// clearer than prose for shapes like `node_groups`.
-function yamlSkeleton(name: string, valueSchema: JSONSchema, isMap: boolean): string {
-  const props = valueSchema.properties ?? {};
-  const required = new Set(valueSchema.required ?? []);
-  const keys = Object.keys(props).sort((a, b) => {
-    const ra = required.has(a);
-    const rb = required.has(b);
-    if (ra !== rb) {
-      return ra ? -1 : 1;
-    }
-    return 0;
-  });
-  const shown = keys.filter((k) => required.has(k));
-  for (const k of keys) {
-    if (shown.length >= 3) {
-      break;
-    }
-    if (!shown.includes(k)) {
-      shown.push(k);
-    }
-  }
-  const placeholder = (s: JSONSchema) => {
-    const t = Array.isArray(s.type) ? s.type[0] : s.type;
-    if (t === 'boolean') return 'true';
-    if (t === 'integer' || t === 'number') return '0';
-    if (t === 'array') return '[]';
-    return `<${typeLabel(s)}>`;
-  };
-  const body = shown.map(
-    (k) => `    ${k}: ${placeholder(props[k])}${required.has(k) ? '   # required' : ''}`,
-  );
-  if (isMap) {
-    return `${name}:\n  <name>:\n${body.join('\n')}`;
-  }
-  return `${name}:\n${body.map((l) => l.slice(2)).join('\n')}`;
 }
 
 function requiredHint(valueSchema: JSONSchema): string {
@@ -378,17 +300,16 @@ function NestedFields({
   );
 }
 
-// Type / required / keyed / default / pattern / enum, all inline on the field
-// name's line. Shared between top-level rows (flex) and nested rows (inline).
+// Type / required / default / pattern / enum, all inline on the field name's
+// line. Everything shown is read from the schema. Shared between top-level rows
+// (flex) and nested rows (inline).
 function MetaChips({
   schema,
   required,
-  emptyObject,
   mapValue,
 }: {
   schema: JSONSchema;
   required: boolean;
-  emptyObject: boolean;
   mapValue: JSONSchema | null;
 }) {
   return (
@@ -403,7 +324,6 @@ function MetaChips({
         )}
       </span>
       {required && <span className={`${styles.chip} ${styles.chipRequired}`}>required</span>}
-      {emptyObject && <span className={`${styles.chip} ${styles.chipKeyed}`}>keyed by provider</span>}
       {schema.default !== undefined && (
         <span className={styles.metaTag}>
           <span className={styles.k}>default</span>
@@ -430,11 +350,11 @@ function MetaChips({
   );
 }
 
-// One field. The name and its inline metadata sit on one line; descriptions,
-// YAML snippets and nested blocks stack below. `nested` is true only for rows
-// inside a <details> (deeper than a section's direct fields): those show their
-// full dotted path as a hover tooltip (not a breadcrumb line), drop the row
-// hairline, and suppress the required/optional group labels.
+// One field. The name and its inline metadata sit on one line; the description,
+// schema examples and nested blocks stack below. Everything is read from the
+// schema. `nested` is true only for rows inside a <details> (deeper than a
+// section's direct fields): those show their full dotted path as a hover tooltip
+// (not a breadcrumb line), drop the row hairline, and suppress the group labels.
 function Field({
   name,
   schema,
@@ -457,34 +377,16 @@ function Field({
   const objProps = schema.properties ? Object.keys(schema.properties).length : 0;
   const mapValue = mapValueSchema(schema);
   const nestedObject = schema.type === 'object' && objProps > 0 ? schema : null;
-  const emptyObject = schema.type === 'object' && objProps === 0 && !mapValue;
   const arrayItems = schema.type === 'array' && schema.items?.properties ? schema.items : null;
   const mapOfObjects = mapValue && mapValue.properties ? mapValue : null;
-
-  // Top-level `cluster`/`dns` are opaque here (keyed by provider); point at the
-  // provider sections that render their fields rather than an empty toggle.
-  const providerRef =
-    path.length === 0 && name === 'cluster'
-      ? 'cluster-providers'
-      : path.length === 0 && name === 'dns'
-        ? 'dns-providers'
-        : null;
 
   const below = (
     <>
       {schema.description && <FieldDescription description={schema.description} />}
-      {emptyObject && providerRef && (
-        <p className={styles.description}>
-          Configured per provider. See <a href={`#${providerRef}`}>the provider section below</a>.
-        </p>
-      )}
       {schema.examples && schema.examples.length > 0 && (
         <CodeBlock language="yaml">
           {schema.examples.map((e) => (typeof e === 'string' ? e : JSON.stringify(e))).join('\n')}
         </CodeBlock>
-      )}
-      {mapOfObjects && (
-        <CodeBlock language="yaml">{yamlSkeleton(name, mapOfObjects, true)}</CodeBlock>
       )}
       {nestedObject && (
         <NestedFields
@@ -513,9 +415,7 @@ function Field({
     </>
   );
 
-  const chips = (
-    <MetaChips schema={schema} required={required} emptyObject={emptyObject} mapValue={mapValue} />
-  );
+  const chips = <MetaChips schema={schema} required={required} mapValue={mapValue} />;
 
   if (nested) {
     return (
@@ -531,7 +431,6 @@ function Field({
 
   const hasBelow =
     !!schema.description ||
-    (emptyObject && !!providerRef) ||
     (!!schema.examples && schema.examples.length > 0) ||
     !!nestedObject ||
     !!arrayItems ||
@@ -564,12 +463,7 @@ function FieldList({
   const names = Object.keys(properties);
 
   if (names.length === 0) {
-    return (
-      <Admonition type="note">
-        This section is keyed by provider name; see the provider-specific
-        reference below for its fields.
-      </Admonition>
-    );
+    return <Admonition type="note">This schema defines no fields.</Admonition>;
   }
 
   const requiredNames = names.filter((n) => required.has(n)).sort();
@@ -816,11 +710,11 @@ function renderSections(data: LoadedSchemas): JSX.Element {
 
       {data.cluster.length > 0 && (
         <section className={styles.section}>
-          <SectionHead id="cluster-providers" title="Cluster providers" meta="exactly one applies" />
-          <p className={styles.sectionIntro}>
-            Configured under <code>cluster.&lt;provider&gt;</code>. Exactly one
-            provider is set per deployment.
-          </p>
+          <SectionHead
+            id="cluster-providers"
+            title="Cluster providers"
+            meta={plural(data.cluster.length, 'provider')}
+          />
           <Tabs queryString="cluster-provider">
             {data.cluster.map(({ name, schema }) => (
               <TabItem key={name} value={name} label={name}>
@@ -833,11 +727,11 @@ function renderSections(data: LoadedSchemas): JSX.Element {
 
       {data.dns.length > 0 && (
         <section className={styles.section}>
-          <SectionHead id="dns-providers" title="DNS providers" meta="exactly one applies" />
-          <p className={styles.sectionIntro}>
-            Configured under <code>dns.&lt;provider&gt;</code>. Credentials (API
-            tokens) are read from environment variables, not from config.
-          </p>
+          <SectionHead
+            id="dns-providers"
+            title="DNS providers"
+            meta={plural(data.dns.length, 'provider')}
+          />
           <Tabs queryString="dns-provider">
             {data.dns.map(({ name, schema }) => (
               <TabItem key={name} value={name} label={name}>

--- a/docs/src/components/NicSchemaLoader/styles.module.css
+++ b/docs/src/components/NicSchemaLoader/styles.module.css
@@ -1,3 +1,86 @@
+/* Two-column layout: schema body + a sticky, schema-derived TOC. The page sets
+   hide_table_of_contents because the native TOC is empty here (every field
+   heading is rendered at runtime), so this component supplies its own rail. */
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 14rem;
+  gap: 2rem;
+  align-items: start;
+}
+
+.content {
+  min-width: 0;
+}
+
+.toc {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+  max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
+  overflow-y: auto;
+  font-size: 0.85rem;
+  border-left: 1px solid var(--ifm-color-emphasis-300);
+  padding-left: 1rem;
+}
+
+.tocTitle {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.5rem;
+}
+
+.tocList,
+.tocChildList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tocChildList {
+  padding-left: 0.75rem;
+}
+
+.tocLink {
+  display: block;
+  padding: 0.15rem 0 0.15rem 0.5rem;
+  margin-left: -0.5rem;
+  border-left: 2px solid transparent;
+  color: var(--ifm-color-emphasis-700);
+  text-decoration: none;
+}
+
+.tocLink:hover {
+  color: var(--ifm-color-primary);
+}
+
+.tocSection {
+  font-weight: 600;
+  margin-top: 0.4rem;
+}
+
+.tocChild {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+}
+
+.tocLinkActive {
+  color: var(--ifm-color-primary);
+  border-left-color: var(--ifm-color-primary);
+}
+
+/* Below the Docusaurus content breakpoint, collapse to a single column and drop
+   the rail (the same point at which the native right TOC would hide). */
+@media (max-width: 996px) {
+  .layout {
+    display: block;
+  }
+  .toc {
+    display: none;
+  }
+}
+
 .toolbar {
   display: flex;
   align-items: center;

--- a/docs/src/components/NicSchemaLoader/styles.module.css
+++ b/docs/src/components/NicSchemaLoader/styles.module.css
@@ -102,14 +102,6 @@
   color: var(--ifm-color-emphasis-600);
 }
 
-.sectionIntro {
-  margin: 16px 0 0;
-  max-width: 64ch;
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--ifm-color-emphasis-700);
-}
-
 /* ---- required / optional group label ---- */
 .groupLabel {
   display: flex;
@@ -233,12 +225,6 @@
   background: var(--ifm-color-primary-contrast-background);
   color: var(--ifm-color-primary-dark);
   border-color: transparent;
-}
-
-.chipKeyed {
-  font-size: 11px;
-  background: none;
-  color: var(--ifm-color-emphasis-600);
 }
 
 .chipEnum {

--- a/docs/src/components/NicSchemaLoader/styles.module.css
+++ b/docs/src/components/NicSchemaLoader/styles.module.css
@@ -131,17 +131,12 @@
   color: var(--ifm-color-primary);
 }
 
-.groupLabel .rule {
-  flex: 1;
-  height: 1px;
-  background: var(--ifm-color-emphasis-200);
-}
-
-/* ---- field row: name | detail ---- */
+/* ---- field row: name + inline meta, with a below block for the rest ---- */
 .fieldRow {
-  display: grid;
-  grid-template-columns: minmax(150px, 232px) minmax(0, 1fr);
-  gap: 28px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px;
   padding: 12px 12px 12px 14px;
   margin-left: -17px;
   border-top: 1px solid var(--ifm-color-emphasis-200);
@@ -152,24 +147,8 @@
   background: var(--ifm-background-surface-color);
 }
 
-.fieldRow:last-child {
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-}
-
 .fieldRowRequired {
   border-left-color: var(--ifm-color-primary);
-}
-
-.nameCol,
-.detailCol {
-  min-width: 0;
-}
-
-.breadcrumb {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 11px;
-  color: var(--ifm-color-emphasis-500);
-  margin-bottom: 2px;
 }
 
 .fieldName {
@@ -190,6 +169,35 @@
   overflow-wrap: anywhere;
 }
 
+/* Description, YAML snippets and nested blocks stack full-width under the name. */
+.below {
+  flex: 0 0 100%;
+  padding-left: 18px;
+  margin-top: 2px;
+}
+
+/* ---- nested field row: no hairline; full path on hover ---- */
+.fieldRowNested {
+  padding: 9px 0 9px 10px;
+  margin-left: -18px;
+  border-left: 2px solid transparent;
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 56px);
+}
+
+.fieldRowNestedRequired {
+  border-left-color: var(--ifm-color-primary);
+}
+
+.fieldNameNested {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13.5px;
+  font-weight: 650;
+  color: var(--ifm-font-color-base);
+  cursor: help;
+  border-bottom: 1px dotted var(--ifm-color-emphasis-400);
+  overflow-wrap: anywhere;
+}
+
 /* ---- meta chips ---- */
 .meta {
   display: flex;
@@ -198,8 +206,13 @@
   gap: 6px;
 }
 
-.metaEnum {
-  margin-top: 6px;
+.metaInline {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-left: 10px;
+  vertical-align: baseline;
 }
 
 .chip {

--- a/docs/src/components/NicSchemaLoader/styles.module.css
+++ b/docs/src/components/NicSchemaLoader/styles.module.css
@@ -1,0 +1,121 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.toolbar select {
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--ifm-global-radius);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+}
+
+.previewBadge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 1rem;
+  background: var(--ifm-color-warning-contrast-background);
+  color: var(--ifm-color-warning-contrast-foreground);
+  border: 1px solid var(--ifm-color-warning-dark);
+}
+
+/* One field entry. A colored left border makes required fields scannable while
+   scrolling past collapsed content (Infima variable => dark-mode aware). */
+.field {
+  padding: 0.1rem 0 0.1rem 0.75rem;
+  margin: 0.75rem 0;
+  border-left: 3px solid transparent;
+}
+
+.fieldRequired {
+  border-left-color: var(--ifm-color-primary);
+}
+
+.breadcrumb {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+  font-family: var(--ifm-font-family-monospace);
+  margin-bottom: 0.15rem;
+}
+
+.name {
+  font-family: var(--ifm-font-family-monospace);
+}
+
+/* Single-line facts row that replaces the old per-field table. */
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0.25rem 0 0.4rem;
+  font-size: 0.85rem;
+}
+
+.chip {
+  padding: 0.05rem 0.4rem;
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.chipRequired {
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-contrast-foreground, #fff);
+}
+
+.chipOptional {
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  border: 1px dashed var(--ifm-color-emphasis-300);
+}
+
+.enumList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+/* Divider that separates required fields from optional ones. */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1.25rem 0 0.5rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--ifm-color-emphasis-300);
+}
+
+/* Vertical guide so nesting depth is visible while scrolling. */
+.nested {
+  border-left: 2px solid var(--ifm-color-emphasis-200);
+  padding-left: 0.75rem;
+  margin-left: 0.1rem;
+}
+
+.description :global(p:last-child) {
+  margin-bottom: 0.3rem;
+}
+
+/* Long, unbreakable values (URLs in descriptions, regex patterns). */
+.field :global(code) {
+  overflow-wrap: anywhere;
+}

--- a/docs/src/components/NicSchemaLoader/styles.module.css
+++ b/docs/src/components/NicSchemaLoader/styles.module.css
@@ -1,34 +1,352 @@
-/* Two-column layout: schema body + a sticky, schema-derived TOC. The page sets
-   hide_table_of_contents because the native TOC is empty here (every field
-   heading is rendered at runtime), so this component supplies its own rail. */
+/* Field-grid design system for the generated config reference. Colors ride on
+   Infima theme variables (already Nebari-purple and light/dark aware); a few
+   reference-specific tokens are layered on the wrapper below and flipped for
+   dark mode. */
 .layout {
+  --sr-code-bg: #f4f2f7;
+  --sr-accent-value: #0f6f72;
+  --sr-warn: #8a5a00;
+  --sr-warn-bg: #fdf4e3;
+
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 14rem;
-  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr) 224px;
+  gap: 48px;
   align-items: start;
+}
+
+:global([data-theme='dark']) .layout {
+  --sr-code-bg: #241f2e;
+  --sr-accent-value: #6fd3d6;
+  --sr-warn: #e6bc6a;
+  --sr-warn-bg: #33291a;
 }
 
 .content {
   min-width: 0;
 }
 
+/* ---- version toolbar ---- */
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  margin-bottom: 40px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--ifm-global-radius);
+}
+
+.toolbarLabel {
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.toolbar select {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12.5px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+.previewBadge {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: var(--sr-warn);
+  background: var(--sr-warn-bg);
+  border: 1px solid currentColor;
+}
+
+.toolbarSpacer {
+  flex: 1;
+}
+
+/* ---- section ---- */
+.section {
+  margin-bottom: 60px;
+}
+
+.sectionHead {
+  position: sticky;
+  top: var(--ifm-navbar-height);
+  z-index: 2;
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 14px 0 10px;
+  background: var(--ifm-background-color);
+  border-bottom: 2px solid var(--ifm-color-emphasis-800);
+}
+
+.sectionHead h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.sectionMeta {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11.5px;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.sectionIntro {
+  margin: 16px 0 0;
+  max-width: 64ch;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ---- required / optional group label ---- */
+.groupLabel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 22px 0 6px;
+}
+
+.groupLabel .tag {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.groupLabelRequired .tag {
+  color: var(--ifm-color-primary);
+}
+
+.groupLabel .rule {
+  flex: 1;
+  height: 1px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+/* ---- field row: name | detail ---- */
+.fieldRow {
+  display: grid;
+  grid-template-columns: minmax(150px, 232px) minmax(0, 1fr);
+  gap: 28px;
+  padding: 12px 12px 12px 14px;
+  margin-left: -17px;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  border-left: 3px solid transparent;
+}
+
+.fieldRow:hover {
+  background: var(--ifm-background-surface-color);
+}
+
+.fieldRow:last-child {
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.fieldRowRequired {
+  border-left-color: var(--ifm-color-primary);
+}
+
+.nameCol,
+.detailCol {
+  min-width: 0;
+}
+
+.breadcrumb {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  color: var(--ifm-color-emphasis-500);
+  margin-bottom: 2px;
+}
+
+.fieldName {
+  margin: 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.4;
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 56px);
+}
+
+.fieldName code {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-size: inherit;
+  color: var(--ifm-font-color-base);
+  overflow-wrap: anywhere;
+}
+
+/* ---- meta chips ---- */
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.metaEnum {
+  margin-top: 6px;
+}
+
+.chip {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: var(--sr-code-bg);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
+  white-space: nowrap;
+}
+
+.chipRequired {
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  background: var(--ifm-color-primary-contrast-background);
+  color: var(--ifm-color-primary-dark);
+  border-color: transparent;
+}
+
+.chipKeyed {
+  font-size: 11px;
+  background: none;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.chipEnum {
+  background: none;
+  color: var(--sr-accent-value);
+}
+
+.accent {
+  color: var(--sr-accent-value);
+}
+
+.enumLabel {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin-right: 2px;
+}
+
+.metaTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12px;
+  padding: 2px 7px 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.metaTag .k {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.metaTag .v {
+  color: var(--sr-accent-value);
+  overflow-wrap: anywhere;
+}
+
+.description {
+  margin-top: 8px;
+  max-width: 64ch;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.description :global(p) {
+  margin: 0;
+}
+
+.description :global(p + p) {
+  margin-top: 0.5rem;
+}
+
+.description :global(code) {
+  overflow-wrap: anywhere;
+}
+
+/* ---- nested fields (collapsible) ---- */
+.nestedDetails {
+  margin-top: 10px;
+}
+
+.nestedDetails > summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.nestedDetails > summary::-webkit-details-marker {
+  display: none;
+}
+
+.nestedDetails[open] > summary .caret {
+  transform: rotate(90deg);
+}
+
+.nestedToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  padding: 5px 9px;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12px;
+  color: var(--ifm-color-emphasis-700);
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+}
+
+.caret {
+  display: inline-block;
+  transition: transform 0.12s ease;
+  color: var(--ifm-color-primary);
+}
+
+.nested {
+  margin: 8px 0 0 6px;
+  padding-left: 16px;
+  border-left: 2px solid var(--ifm-color-emphasis-200);
+}
+
+/* ---- right rail ---- */
 .toc {
   position: sticky;
-  top: calc(var(--ifm-navbar-height) + 1rem);
-  max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
+  top: calc(var(--ifm-navbar-height) + 24px);
+  max-height: calc(100vh - var(--ifm-navbar-height) - 48px);
   overflow-y: auto;
-  font-size: 0.85rem;
-  border-left: 1px solid var(--ifm-color-emphasis-300);
-  padding-left: 1rem;
+  padding-top: 44px;
 }
 
 .tocTitle {
-  font-size: 0.7rem;
+  font-size: 11px;
   font-weight: 700;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
   color: var(--ifm-color-emphasis-600);
-  margin-bottom: 0.5rem;
+  padding: 0 0 10px 12px;
 }
 
 .tocList,
@@ -38,31 +356,38 @@
   padding: 0;
 }
 
+.tocList {
+  border-left: 1px solid var(--ifm-color-emphasis-200);
+}
+
 .tocChildList {
-  padding-left: 0.75rem;
+  padding-left: 0;
 }
 
 .tocLink {
   display: block;
-  padding: 0.15rem 0 0.15rem 0.5rem;
-  margin-left: -0.5rem;
+  margin-left: -1px;
+  padding: 4px 12px;
   border-left: 2px solid transparent;
-  color: var(--ifm-color-emphasis-700);
+  color: var(--ifm-color-emphasis-600);
   text-decoration: none;
 }
 
 .tocLink:hover {
   color: var(--ifm-color-primary);
+  text-decoration: none;
 }
 
 .tocSection {
-  font-weight: 600;
-  margin-top: 0.4rem;
+  font-size: 13px;
+  font-weight: 650;
+  padding-top: 8px;
+  color: var(--ifm-color-emphasis-700);
 }
 
 .tocChild {
   font-family: var(--ifm-font-family-monospace);
-  font-size: 0.8rem;
+  font-size: 12.5px;
 }
 
 .tocLinkActive {
@@ -70,8 +395,7 @@
   border-left-color: var(--ifm-color-primary);
 }
 
-/* Below the Docusaurus content breakpoint, collapse to a single column and drop
-   the rail (the same point at which the native right TOC would hide). */
+/* ---- responsive ---- */
 @media (max-width: 996px) {
   .layout {
     display: block;
@@ -81,124 +405,9 @@
   }
 }
 
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  margin-bottom: 1rem;
-}
-
-.toolbar select {
-  padding: 0.2rem 0.4rem;
-  border-radius: var(--ifm-global-radius);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  background: var(--ifm-background-surface-color);
-  color: var(--ifm-font-color-base);
-}
-
-.previewBadge {
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 0.1rem 0.45rem;
-  border-radius: 1rem;
-  background: var(--ifm-color-warning-contrast-background);
-  color: var(--ifm-color-warning-contrast-foreground);
-  border: 1px solid var(--ifm-color-warning-dark);
-}
-
-/* One field entry. A colored left border makes required fields scannable while
-   scrolling past collapsed content (Infima variable => dark-mode aware). */
-.field {
-  padding: 0.1rem 0 0.1rem 0.75rem;
-  margin: 0.75rem 0;
-  border-left: 3px solid transparent;
-}
-
-.fieldRequired {
-  border-left-color: var(--ifm-color-primary);
-}
-
-.breadcrumb {
-  font-size: 0.8rem;
-  color: var(--ifm-color-emphasis-600);
-  font-family: var(--ifm-font-family-monospace);
-  margin-bottom: 0.15rem;
-}
-
-.name {
-  font-family: var(--ifm-font-family-monospace);
-}
-
-/* Single-line facts row that replaces the old per-field table. */
-.meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.4rem;
-  margin: 0.25rem 0 0.4rem;
-  font-size: 0.85rem;
-}
-
-.chip {
-  padding: 0.05rem 0.4rem;
-  border-radius: var(--ifm-global-radius);
-  background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-color-emphasis-800);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 0.8rem;
-  white-space: nowrap;
-}
-
-.chipRequired {
-  background: var(--ifm-color-primary);
-  color: var(--ifm-color-primary-contrast-foreground, #fff);
-}
-
-.chipOptional {
-  background: transparent;
-  color: var(--ifm-color-emphasis-600);
-  border: 1px dashed var(--ifm-color-emphasis-300);
-}
-
-.enumList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-  align-items: center;
-}
-
-/* Divider that separates required fields from optional ones. */
-.divider {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 1.25rem 0 0.5rem;
-  color: var(--ifm-color-emphasis-600);
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.divider::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--ifm-color-emphasis-300);
-}
-
-/* Vertical guide so nesting depth is visible while scrolling. */
-.nested {
-  border-left: 2px solid var(--ifm-color-emphasis-200);
-  padding-left: 0.75rem;
-  margin-left: 0.1rem;
-}
-
-.description :global(p:last-child) {
-  margin-bottom: 0.3rem;
-}
-
-/* Long, unbreakable values (URLs in descriptions, regex patterns). */
-.field :global(code) {
-  overflow-wrap: anywhere;
+@media (max-width: 700px) {
+  .fieldRow {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
+  }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7356,6 +7356,16 @@ mdast-util-directive@^3.0.0:
     stringify-entities "^4.0.0"
     unist-util-visit-parents "^6.0.0"
 
+mdast-util-find-and-replace@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz#cc2b774f7f3630da4bd592f61966fecade8b99b1"
+  integrity sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    escape-string-regexp "^5.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
+
 mdast-util-find-and-replace@^3.0.0, mdast-util-find-and-replace@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz"
@@ -7414,6 +7424,16 @@ mdast-util-frontmatter@^2.0.0:
     mdast-util-to-markdown "^2.0.0"
     micromark-extension-frontmatter "^2.0.0"
 
+mdast-util-gfm-autolink-literal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz#67a13abe813d7eba350453a5333ae1bc0ec05c06"
+  integrity sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    ccount "^2.0.0"
+    mdast-util-find-and-replace "^2.0.0"
+    micromark-util-character "^1.0.0"
+
 mdast-util-gfm-autolink-literal@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz"
@@ -7424,6 +7444,15 @@ mdast-util-gfm-autolink-literal@^2.0.0:
     devlop "^1.0.0"
     mdast-util-find-and-replace "^3.0.0"
     micromark-util-character "^2.0.0"
+
+mdast-util-gfm-footnote@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz#ce5e49b639c44de68d5bf5399877a14d5020424e"
+  integrity sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.3.0"
+    micromark-util-normalize-identifier "^1.0.0"
 
 mdast-util-gfm-footnote@^2.0.0:
   version "2.0.0"
@@ -7436,6 +7465,14 @@ mdast-util-gfm-footnote@^2.0.0:
     mdast-util-to-markdown "^2.0.0"
     micromark-util-normalize-identifier "^2.0.0"
 
+mdast-util-gfm-strikethrough@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz#5470eb105b483f7746b8805b9b989342085795b7"
+  integrity sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.3.0"
+
 mdast-util-gfm-strikethrough@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz"
@@ -7444,6 +7481,16 @@ mdast-util-gfm-strikethrough@^2.0.0:
     "@types/mdast" "^4.0.0"
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm-table@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz#3552153a146379f0f9c4c1101b071d70bbed1a46"
+  integrity sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    markdown-table "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    mdast-util-to-markdown "^1.3.0"
 
 mdast-util-gfm-table@^2.0.0:
   version "2.0.0"
@@ -7456,6 +7503,14 @@ mdast-util-gfm-table@^2.0.0:
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
 
+mdast-util-gfm-task-list-item@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz#b280fcf3b7be6fd0cc012bbe67a59831eb34097b"
+  integrity sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-markdown "^1.3.0"
+
 mdast-util-gfm-task-list-item@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz"
@@ -7465,6 +7520,19 @@ mdast-util-gfm-task-list-item@^2.0.0:
     devlop "^1.0.0"
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz#e92f4d8717d74bdba6de57ed21cc8b9552e2d0b6"
+  integrity sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==
+  dependencies:
+    mdast-util-from-markdown "^1.0.0"
+    mdast-util-gfm-autolink-literal "^1.0.0"
+    mdast-util-gfm-footnote "^1.0.0"
+    mdast-util-gfm-strikethrough "^1.0.0"
+    mdast-util-gfm-table "^1.0.0"
+    mdast-util-gfm-task-list-item "^1.0.0"
+    mdast-util-to-markdown "^1.0.0"
 
 mdast-util-gfm@^3.0.0:
   version "3.0.0"
@@ -7533,6 +7601,14 @@ mdast-util-mdxjs-esm@^2.0.0:
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
 
+mdast-util-phrasing@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz#c7c21d0d435d7fb90956038f02e8702781f95463"
+  integrity sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    unist-util-is "^5.0.0"
+
 mdast-util-phrasing@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz"
@@ -7570,6 +7646,20 @@ mdast-util-to-hast@^13.0.0:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
+mdast-util-to-markdown@^1.0.0, mdast-util-to-markdown@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz#c13343cb3fc98621911d33b5cd42e7d0731171c6"
+  integrity sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-phrasing "^3.0.0"
+    mdast-util-to-string "^3.0.0"
+    micromark-util-decode-string "^1.0.0"
+    unist-util-visit "^4.0.0"
+    zwitch "^2.0.0"
+
 mdast-util-to-markdown@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz"
@@ -7584,7 +7674,7 @@ mdast-util-to-markdown@^2.0.0:
     unist-util-visit "^5.0.0"
     zwitch "^2.0.0"
 
-mdast-util-to-string@^3.1.0:
+mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz#66f7bb6324756741c5f47a53557f0cbf16b6f789"
   integrity sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==
@@ -7666,7 +7756,7 @@ methods@~1.1.2:
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micromark-core-commonmark@^1.0.1:
+micromark-core-commonmark@^1.0.0, micromark-core-commonmark@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz#1386628df59946b2d39fb2edfd10f3e8e0a75bb8"
   integrity sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==
@@ -7733,6 +7823,16 @@ micromark-extension-frontmatter@^2.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-extension-gfm-autolink-literal@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz#5853f0e579bbd8ef9e39a7c0f0f27c5a063a66e7"
+  integrity sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
 micromark-extension-gfm-autolink-literal@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz"
@@ -7742,6 +7842,20 @@ micromark-extension-gfm-autolink-literal@^2.0.0:
     micromark-util-sanitize-uri "^2.0.0"
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-footnote@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz#05e13034d68f95ca53c99679040bc88a6f92fe2e"
+  integrity sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==
+  dependencies:
+    micromark-core-commonmark "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
 
 micromark-extension-gfm-footnote@^2.0.0:
   version "2.1.0"
@@ -7757,6 +7871,18 @@ micromark-extension-gfm-footnote@^2.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-extension-gfm-strikethrough@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz#c8212c9a616fa3bf47cb5c711da77f4fdc2f80af"
+  integrity sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
 micromark-extension-gfm-strikethrough@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz"
@@ -7769,6 +7895,17 @@ micromark-extension-gfm-strikethrough@^2.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-extension-gfm-table@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz#dcb46074b0c6254c3fc9cc1f6f5002c162968008"
+  integrity sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
 micromark-extension-gfm-table@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz"
@@ -7780,12 +7917,30 @@ micromark-extension-gfm-table@^2.0.0:
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
 
+micromark-extension-gfm-tagfilter@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz#aa7c4dd92dabbcb80f313ebaaa8eb3dac05f13a7"
+  integrity sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==
+  dependencies:
+    micromark-util-types "^1.0.0"
+
 micromark-extension-gfm-tagfilter@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz"
   integrity sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==
   dependencies:
     micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-task-list-item@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz#b52ce498dc4c69b6a9975abafc18f275b9dde9f4"
+  integrity sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
 
 micromark-extension-gfm-task-list-item@^2.0.0:
   version "2.1.0"
@@ -7797,6 +7952,20 @@ micromark-extension-gfm-task-list-item@^2.0.0:
     micromark-util-character "^2.0.0"
     micromark-util-symbol "^2.0.0"
     micromark-util-types "^2.0.0"
+
+micromark-extension-gfm@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz#e517e8579949a5024a493e49204e884aa74f5acf"
+  integrity sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==
+  dependencies:
+    micromark-extension-gfm-autolink-literal "^1.0.0"
+    micromark-extension-gfm-footnote "^1.0.0"
+    micromark-extension-gfm-strikethrough "^1.0.0"
+    micromark-extension-gfm-table "^1.0.0"
+    micromark-extension-gfm-tagfilter "^1.0.0"
+    micromark-extension-gfm-task-list-item "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-types "^1.0.0"
 
 micromark-extension-gfm@^3.0.0:
   version "3.0.0"
@@ -9792,6 +9961,16 @@ remark-frontmatter@^5.0.0:
     micromark-extension-frontmatter "^2.0.0"
     unified "^11.0.0"
 
+remark-gfm@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"
+  integrity sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-gfm "^2.0.0"
+    micromark-extension-gfm "^2.0.0"
+    unified "^10.0.0"
+
 remark-gfm@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz"
@@ -11178,7 +11357,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit-parents@^5.1.1:
+unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
   integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==


### PR DESCRIPTION
## Reference Issues or PRs

Part of #632 / #665 - the auto-generated reference-docs work (the **config schema** leg). Producer: the config-schema generation pipeline in [`nebari-infrastructure-core#362`](https://github.com/nebari-dev/nebari-infrastructure-core/pull/362).

## What does this implement/fix?

- [x] New feature (non-breaking)
- [x] Documentation Update

A **PoC** for rendering the NIC configuration reference directly from the JSON Schema that `nebari-infrastructure-core` generates from its Go config structs. Because the page is driven by the generated schema, it cannot drift from the config the CLI actually accepts - which is exactly what #632/#665 require ("no hand-edited field lists").

This revives the approach from the closed legacy PR #453 (`NebariSchemaLoader`), but re-targeted at the **new NIC architecture** instead of legacy Nebari's pydantic schema.

### What's here

- `docs/src/components/NicSchemaLoader/index.tsx` - fetches the producer's `schemas/manifest.json` (`{ providers, dns, top_level }`), then the top-level and per-provider schema files, and renders them. Modernized for Docusaurus 3 / React 18 (the #453 component targeted Docusaurus 2 beta / React 17).
- `docs/docs/references/config-schema.mdx` - the reference page, wired into the References sidebar.
- `remark-gfm` added so GitHub-flavored markdown in schema descriptions renders.

### How it differs from the legacy #453 loader

1. **Manifest-driven, multi-file** - #453 fetched one monolithic schema; the NIC producer emits a manifest + top-level + per-provider files.
2. **Own `$defs` dereferencer** - the generated schemas use recursive same-file `#/$defs/...` refs that generic `$ref` resolvers (incl. `@stoplight/json-ref-resolver`, which I tried first) leave un-inlined. A small local dereference with a cycle guard handles them, and correctly expands map types (e.g. `node_groups` -> `map<NodeGroup>`) and nested objects (`certificate.acme`).
3. **Dropped legacy keywords** - `optionsAre`, `note`, `depends_on`, `group_by` were pydantic-era extensions; the invopop output doesn't use them.
4. **Per-provider structure** - top-level config, then cluster providers (tabbed) and DNS providers (tabbed), matching #665's "per-provider schema pages".
5. **Source of truth** - points at `raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/<ref>/schemas`, versionable by tag.

## Draft, because

- The producer ([`nebari-infrastructure-core#362`](https://github.com/nebari-dev/nebari-infrastructure-core/pull/362)) is itself still Draft. The component **tracks the `feat/config-schema-gen` branch** for now (a constant at the top of the component); once #362 lands on a tagged release, that `ref` should pin to the tag so the docs are versioned.
- The **drift-detection CI** that #632 calls for is not included yet - this is the render half. Follow-up: fail the docs build if the pinned schema is missing/stale.

## Testing

- [x] `yarn build` compiles the component and builds the site (SSR renders the loading state; no new broken links/anchors from this change).
- [x] The manifest + `$defs` dereference logic verified against the **real** #362 schema output: all 6 cluster providers + Cloudflare resolve, `node_groups` expands as a map with its 9 value fields, and `certificate.acme` (email, server) inlines correctly.
- [ ] Live in-browser render (`yarn start`) - needs network access to the branch raw URL; worth an eyeball before this leaves Draft.

## Related

The producer side also has a proposed **`nic config init`** config-builder command (ADR-0005 in NIC, via `nebari-infrastructure-core#360`) - same "Go types are the single source of truth" story, CLI-side rather than docs-side.

## Access-centered content checklist

- [x] Content uses plain language.
- [x] One `H1`; schema fields render under proper heading levels.
- [x] Links describe where they go.
