### PR TITLE
docs(providers): add Azure and Local (kind) provider pages

### DIFF
--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -7,7 +7,7 @@ description: End-to-end how-to for deploying, updating, and destroying NKP on AW
 This guide walks through deploying NKP on AWS with `nic` (the Nebari Infrastructure Core CLI), from an empty AWS account to a running cluster you can manage and tear down.
 
 :::warning[A cloud deployment is not free]
-Deploying NKP on AWS provisions real, billed infrastructure — it is **not** a free-tier workload. The EKS control plane, NAT gateways, and load balancers bill regardless of instance size, and the smallest working cluster needs multi-GB nodes (the example uses a 4 vCPU / 16 GB instance) that are well beyond free-tier sizes. To try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
+A NKP deployment on AWS will **not** fall within free-tier usage — some of its components (the EKS control plane, NAT gateways, and load balancers) lead to additional charges regardless of instance size, and the smallest working cluster needs multi-GB nodes well beyond free-tier sizes. We recommend reviewing the [AWS pricing documentation](https://aws.amazon.com/pricing/), or checking with your cloud administrator, before you deploy. To try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
 :::
 
 ## What your team gets
@@ -23,7 +23,7 @@ When `nic deploy` finishes, your team will have all [standard NKP services](/doc
 
 You'll need access to an AWS account you can deploy into. If you don't have one, [create an AWS account](https://aws.amazon.com/) — a new account works, but keep the note above in mind: NKP is a billed workload, not a free-tier one.
 
-- **Region:** pick one where [EKS is available](https://docs.aws.amazon.com/eks/latest/userguide/eks-regions.html) and has at least two [availability zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). The example uses `us-west-2a` and `us-west-2b`.
+- **Region:** pick one where [EKS is available](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) and has at least two [availability zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). The example uses `us-west-2a` and `us-west-2b`.
 - **Quotas:** confirm your region has enough [EKS service quota](https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) for the cluster you're about to create. New accounts often need an increase.
 - **Cost:** EKS, NAT gateways, load balancers, and EFS all bill from day one, regardless of instance size. See [Cost considerations](#cost-considerations) for the full list.
 

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -7,7 +7,7 @@ description: End-to-end how-to for deploying, updating, and destroying NKP on AW
 This guide walks through deploying NKP on AWS with `nic` (the Nebari Infrastructure Core CLI), from an empty AWS account to a running cluster you can manage and tear down.
 
 :::warning[A cloud deployment is not free]
-A NKP deployment on AWS will **not** fall within free-tier usage — some of its components (the EKS control plane, NAT gateways, and load balancers) lead to additional charges regardless of instance size, and the smallest working cluster needs multi-GB nodes well beyond free-tier sizes. We recommend reviewing the [AWS pricing documentation](https://aws.amazon.com/pricing/), or checking with your cloud administrator, before you deploy. To try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
+A NKP deployment on AWS will **not** fall within free-tier usage. Some of its components (the EKS control plane, NAT gateways, and load balancers) lead to additional charges regardless of instance size, and the smallest working cluster needs multi-GB nodes well beyond free-tier sizes. We recommend reviewing the [AWS pricing documentation](https://aws.amazon.com/pricing/), or checking with your cloud administrator, before you deploy. To try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
 :::
 
 ## What your team gets
@@ -21,7 +21,7 @@ When `nic deploy` finishes, your team will have all [standard NKP services](/doc
 
 ### AWS account
 
-You'll need access to an AWS account you can deploy into. If you don't have one, [create an AWS account](https://aws.amazon.com/) — a new account works, but keep the note above in mind: NKP is a billed workload, not a free-tier one.
+You'll need access to an AWS account you can deploy into. If you don't have one, [create an AWS account](https://aws.amazon.com/); a new account works, but keep the note above in mind: NKP is a billed workload, not a free-tier one.
 
 - **Region:** pick one where [EKS is available](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) and has at least two [availability zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). The example uses `us-west-2a` and `us-west-2b`.
 - **Quotas:** confirm your region has enough [EKS service quota](https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) for the cluster you're about to create. New accounts often need an increase.
@@ -158,7 +158,7 @@ Follow [Deploy a cluster](/docs/how-tos/deploy-cluster) to deploy and verify. Th
 **After deploy**, DNS handling depends on which config you chose: `aws-config.yaml` requires a manual A/CNAME record; `aws-config-with-dns.yaml` creates DNS records automatically. See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for details.
 
 :::note
-Verifying on AWS also needs the [AWS CLI](https://aws.amazon.com/cli/) — the generated kubeconfig calls `aws eks get-token` to authenticate. If `kubectl` fails with `Token has expired and refresh failed`, your AWS SSO session timed out (default 8 hours); run `aws sso login --profile <aws-profile>` and retry.
+Verifying on AWS also needs the [AWS CLI](https://aws.amazon.com/cli/): the generated kubeconfig calls `aws eks get-token` to authenticate. If `kubectl` fails with `Token has expired and refresh failed`, your AWS SSO session timed out (default 8 hours); run `aws sso login --profile <aws-profile>` and retry.
 :::
 
 ## IAM roles `nic` creates in your account
@@ -187,7 +187,7 @@ Changing `region`, `project_name`, or `vpc_cidr_block` triggers destructive reso
 
 ## Upgrade Kubernetes version
 
-EKS requires one-minor-version increments — you cannot skip versions or downgrade. To go from 1.32 to 1.34 you must upgrade twice:
+EKS requires one-minor-version increments; you cannot skip versions or downgrade. To go from 1.32 to 1.34 you must upgrade twice:
 
 ```
 1.32 → 1.33 → 1.34
@@ -203,14 +203,14 @@ cluster:
     kubernetes_version: "1.33"   # was "1.32"
 ```
 
-EKS accepts bare minor versions (`"1.33"`) — patch versions are not required.
+EKS accepts bare minor versions (`"1.33"`); patch versions are not required.
 
 EKS upgrades in two phases:
 
 1. **Control plane** upgrades first. The Kubernetes API server and control-plane components are updated to the new version. This takes around 10 minutes and is handled by AWS.
-2. **Node groups** roll one at a time. EKS launches a replacement node, waits for it to become Ready, then drains and terminates the old one — one node at a time per node group. Node groups upgrade sequentially after the control plane finishes. Plan for 20–40 minutes total depending on the number of node groups.
+2. **Node groups** roll one at a time. EKS launches a replacement node, waits for it to become Ready, then drains and terminates the old one, one node at a time per node group. Node groups upgrade sequentially after the control plane finishes. Plan for 20–40 minutes total depending on the number of node groups.
 
-After upgrading, verify your EKS managed add-ons (kube-proxy, CoreDNS, VPC CNI) are on versions compatible with the new cluster version — check the **Add-ons** tab in the AWS EKS console and update any that are flagged.
+After upgrading, verify your EKS managed add-ons (kube-proxy, CoreDNS, VPC CNI) are on versions compatible with the new cluster version; check the **Add-ons** tab in the AWS EKS console and update any that are flagged.
 
 See [Upgrade Kubernetes version](/docs/how-tos/upgrade-kubernetes) for the upgrade commands and post-upgrade verification steps.
 

--- a/docs/docs/how-tos/providers/aws.mdx
+++ b/docs/docs/how-tos/providers/aws.mdx
@@ -6,6 +6,10 @@ description: End-to-end how-to for deploying, updating, and destroying NKP on AW
 
 This guide walks through deploying NKP on AWS with `nic` (the Nebari Infrastructure Core CLI), from an empty AWS account to a running cluster you can manage and tear down.
 
+:::warning[A cloud deployment is not free]
+Deploying NKP on AWS provisions real, billed infrastructure — it is **not** a free-tier workload. The EKS control plane, NAT gateways, and load balancers bill regardless of instance size, and the smallest working cluster needs multi-GB nodes (the example uses a 4 vCPU / 16 GB instance) that are well beyond free-tier sizes. To try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
+:::
+
 ## What your team gets
 
 When `nic deploy` finishes, your team will have all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
@@ -17,11 +21,11 @@ When `nic deploy` finishes, your team will have all [standard NKP services](/doc
 
 ### AWS account
 
-You'll need access to an AWS account you can deploy into. If you don't have one, [sign up for AWS](https://aws.amazon.com/free/).
+You'll need access to an AWS account you can deploy into. If you don't have one, [create an AWS account](https://aws.amazon.com/) — a new account works, but keep the note above in mind: NKP is a billed workload, not a free-tier one.
 
 - **Region:** pick one where [EKS is available](https://docs.aws.amazon.com/eks/latest/userguide/eks-regions.html) and has at least two [availability zones](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). The example uses `us-west-2a` and `us-west-2b`.
 - **Quotas:** confirm your region has enough [EKS service quota](https://docs.aws.amazon.com/eks/latest/userguide/service-quotas.html) for the cluster you're about to create. New accounts often need an increase.
-- **Cost:** NKP does not fit within the free tier; EKS, NAT gateways, and EFS all bill from day one.
+- **Cost:** EKS, NAT gateways, load balancers, and EFS all bill from day one, regardless of instance size. See [Cost considerations](#cost-considerations) for the full list.
 
 ### IAM permissions
 

--- a/docs/docs/how-tos/providers/azure.mdx
+++ b/docs/docs/how-tos/providers/azure.mdx
@@ -1,11 +1,191 @@
 ---
 title: Microsoft Azure
 slug: /how-tos/providers/azure
-description: Planned NKP support for Microsoft Azure.
+description: End-to-end how-to for deploying, updating, and destroying NKP on Azure AKS, including credentials and cost considerations.
 ---
 
-import PlannedProvider from '@site/src/components/PlannedProvider';
+This guide walks through deploying NKP on Microsoft Azure with `nic` (the Nebari Infrastructure Core CLI), from an empty subscription to a running cluster you can manage and tear down. `nic` provisions a managed AKS cluster, analogous to the AWS EKS path.
 
-# Microsoft Azure
+## What your team gets
 
-<PlannedProvider stub="azure" />
+When `nic deploy` finishes, your team will have all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
+
+- **A managed Kubernetes cluster** ready for workloads (Azure AKS, with a System and one or more User node pools).
+- **Block storage** through Azure managed disks (the `managed-csi` StorageClass).
+
+:::note
+Shared read-write-many storage (the Longhorn/EFS equivalent) is not yet wired for Azure, so persistent volumes are read-write-once managed disks.
+:::
+
+## Prerequisites
+
+### Azure subscription
+
+You'll need access to an Azure subscription you can deploy into. If you don't have one, [create a free account](https://azure.microsoft.com/free/).
+
+- **Region:** pick a [region where AKS is available](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=kubernetes-service). The example uses `eastus`.
+- **Quotas:** confirm your subscription has enough [regional vCPU quota](https://learn.microsoft.com/azure/quotas/view-quotas) for the VM sizes in your node pools. New subscriptions often need an increase.
+- **Cost:** NKP does not fit within the free tier; the AKS node pool VMs, managed disks, and load balancer all bill from day one.
+
+### Credentials
+
+`nic` requires your subscription ID and resolves everything else through the standard Azure credential chain ([`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/azure-sdk-authentication)), which tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
+
+The simplest path is the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli):
+
+```bash
+az login
+az account show --query id --output tsv   # this is your subscription ID
+```
+
+For automation, create a service principal instead and use its client/tenant/secret:
+
+```bash
+az ad sp create-for-rbac --name nic-deploy --role Contributor \
+  --scopes /subscriptions/<subscription-id>
+```
+
+### Install nic
+
+Follow the [Install NIC](/docs/get-started/install) guide to download and install the `nic` CLI for your platform.
+
+### GitOps repository
+
+See [GitOps repository](/docs/how-tos/prepare-to-deploy#gitops-repository) in the Prepare to deploy guide.
+
+### Secrets and credentials
+
+From inside your GitOps repo clone, download the [template](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/.env.example):
+
+```bash
+cd /path/to/your-gitops-repo
+curl -o .env https://raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/main/.env.example
+```
+
+Then set your subscription ID and the GitOps tokens. For `.gitignore` setup and GitOps token configuration, see [Secrets and credentials](/docs/how-tos/prepare-to-deploy#secrets-and-credentials) in the Prepare to deploy guide.
+
+```bash
+# Azure
+AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000  # az account show --query id
+# Service-principal auth (only if you are not using `az login`):
+# AZURE_CLIENT_ID=...
+# AZURE_TENANT_ID=...
+# AZURE_CLIENT_SECRET=...
+```
+
+`nic` exports `AZURE_SUBSCRIPTION_ID` to the underlying OpenTofu run as `ARM_SUBSCRIPTION_ID`; you don't need to set the `ARM_*` variables yourself.
+
+## Cost considerations
+
+A NKP deployment provisions several Azure services that bill from day one. Check the [Azure pricing calculator](https://azure.microsoft.com/pricing/calculator/) for current rates in your region.
+
+- **[AKS control plane](https://azure.microsoft.com/pricing/details/kubernetes-service/):** the `Free` SKU tier (the example default) has no control-plane charge; `Standard` adds a per-cluster hourly fee for the uptime SLA.
+- **[Virtual machines](https://azure.microsoft.com/pricing/details/virtual-machines/linux/)** in your node pools: per-hour VM cost for each running node.
+- **[Managed disks](https://azure.microsoft.com/pricing/details/managed-disks/):** OS disks on each node plus any `managed-csi` persistent volumes.
+- **[Load balancer](https://azure.microsoft.com/pricing/details/load-balancer/):** the Standard Load Balancer AKS uses for ingress, plus a public IP.
+- **[Bandwidth](https://azure.microsoft.com/pricing/details/bandwidth/):** outbound data transfer.
+
+## Configuration
+
+Download the starter config from `nebari-infrastructure-core`:
+
+- **[`azure-config.yaml`](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/examples/azure-config.yaml)**.
+
+```bash
+curl -O https://raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/main/examples/azure-config.yaml
+```
+
+:::note
+In later steps, `<config-file>` refers to this local copy (`azure-config.yaml`).
+:::
+
+At minimum, edit these fields:
+
+```yaml
+project_name: my-cluster          # lowercase alphanumeric
+domain: nebari.example.com        # a hostname you own
+
+certificate:
+  type: letsencrypt
+  acme:
+    email: you@example.com        # required for Let's Encrypt; renewal notices go here
+
+git_repository:
+  url: "git@github.com:<your-org>/<your-gitops-repo>.git"
+  path: clusters/my-cluster       # subdirectory in the repo; conventionally matches project_name
+  auth:
+    ssh_key_env: GIT_SSH_PRIVATE_KEY
+
+cluster:
+  azure:
+    region: eastus                # an AKS-supported region
+    kubernetes_version: "1.34"
+    node_groups:
+      # Exactly one node group must be mode: System (it hosts cluster services).
+      system:
+        instance: Standard_D4_v3
+        min_nodes: 1
+        max_nodes: 3
+        mode: System
+      user:
+        instance: Standard_D8_v3
+        min_nodes: 1
+        max_nodes: 5
+```
+
+By default `nic` creates a resource group named `<project_name>-rg`. Set `resource_group_name` to deploy into one you manage.
+
+For the full schema (custom networking, private clusters, `sku_tier`, Node Auto Provisioning, authorized IP ranges), see the [Azure provider reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#25-clusterazure-aks).
+
+## Deploy and verify
+
+Follow [Deploy a cluster](/docs/how-tos/deploy-cluster) to deploy and verify. The first deployment takes at least 20 minutes as AKS provisions the control plane and node pools, followed by ArgoCD syncing foundational services.
+
+Azure does not write a kubeconfig to a cache path. Fetch a cluster-admin kubeconfig with `nic` and point `kubectl` at it:
+
+```bash
+nic kubeconfig -f <config-file> -o kubeconfig
+export KUBECONFIG=$PWD/kubeconfig
+```
+
+Then follow the [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) steps to check the cluster and ArgoCD applications. See [Cloudflare DNS](/docs/how-tos/cloudflare-dns) for DNS setup (Cloudflare or a manual A record).
+
+## First sign-in
+
+See [Keycloak authentication](/docs/how-tos/keycloak-auth) for first sign-in.
+
+## Update an existing deployment
+
+To change something about a running cluster (scale a node pool, add a pool, change tags), edit your config and re-run the deploy commands as described in [Update a cluster](/docs/how-tos/update-cluster).
+
+:::warning
+Changing `region`, `project_name`, or `resource_group_name` triggers destructive resource recreation. Treat these as one-way decisions.
+:::
+
+## Upgrade Kubernetes version
+
+AKS upgrades one minor version at a time — you cannot skip versions or downgrade. To go from 1.32 to 1.34 you must upgrade twice:
+
+```
+1.32 → 1.33 → 1.34
+```
+
+Set `kubernetes_version` under `cluster.azure` in your config:
+
+```yaml
+cluster:
+  azure:
+    kubernetes_version: "1.33"   # was "1.32"
+```
+
+AKS upgrades the control plane first, then rolls each node pool one node at a time — surging in a new node, waiting for it to become Ready, then draining and removing the old one. Plan for 20–40 minutes total depending on the number of node pools.
+
+See [Upgrade Kubernetes version](/docs/how-tos/upgrade-kubernetes) for the upgrade commands and post-upgrade verification steps.
+
+## Destroy
+
+Run the destroy commands as described in [Destroy a cluster](/docs/how-tos/destroy-cluster).
+
+`nic destroy` removes the AKS cluster, its node pools, the load balancer, and (when `nic` created it) the `<project_name>-rg` resource group. If a resource fails to delete, remove it manually in the Azure portal before retrying with `--force`.
+
+Always confirm in the Azure portal that no orphan resources remain — VMs, managed disks, public IPs, and load balancers can keep billing if they're left behind.

--- a/docs/docs/how-tos/providers/azure.mdx
+++ b/docs/docs/how-tos/providers/azure.mdx
@@ -4,46 +4,50 @@ slug: /how-tos/providers/azure
 description: End-to-end how-to for deploying, updating, and destroying NKP on Azure AKS, including credentials and cost considerations.
 ---
 
-This guide walks through deploying NKP on Microsoft Azure with `nic` (the Nebari Infrastructure Core CLI), from an empty subscription to a running cluster you can manage and tear down. `nic` provisions a managed AKS cluster, analogous to the AWS EKS path.
+[Microsoft Azure](https://azure.microsoft.com/) is Microsoft's public cloud. NKP deploys onto it as a managed [AKS (Azure Kubernetes Service)](https://learn.microsoft.com/azure/aks/) cluster, so Azure runs and upgrades the Kubernetes control plane for you while `nic` (the Nebari Infrastructure Core CLI) provisions the cluster, the node pools, and the supporting infrastructure.
+
+This guide walks you through a deployment from end to end — from an empty subscription to a running cluster you can manage and tear down. If you have deployed NKP on AWS, the flow will feel familiar: the differences are mostly in how you authenticate and in a few Azure-specific fields.
 
 ## What your team gets
 
 When `nic deploy` finishes, your team will have all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
 
-- **A managed Kubernetes cluster** ready for workloads (Azure AKS, with a System and one or more User node pools).
+- **A managed Kubernetes cluster** ready for workloads (Azure AKS, with a System node pool and one or more User node pools).
 - **Block storage** through Azure managed disks (the `managed-csi` StorageClass).
 
 :::note
-Shared read-write-many storage (the Longhorn/EFS equivalent) is not yet wired for Azure, so persistent volumes are read-write-once managed disks.
+Shared read-write-many storage (the Longhorn or EFS equivalent) is not yet wired for Azure, so persistent volumes are read-write-once managed disks. NKP also fixes a couple of cluster settings you cannot currently override: networking uses [Azure CNI Overlay](https://learn.microsoft.com/azure/aks/azure-cni-overlay), and the cluster runs under a user-assigned managed identity.
 :::
 
 ## Prerequisites
 
 ### Azure subscription
 
-You'll need access to an Azure subscription you can deploy into. If you don't have one, [create a free account](https://azure.microsoft.com/free/).
+You will need access to an Azure subscription you can deploy into. If you do not have one, [create a free account](https://azure.microsoft.com/free/).
 
 - **Region:** pick a [region where AKS is available](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=kubernetes-service). The example uses `eastus`.
-- **Quotas:** confirm your subscription has enough [regional vCPU quota](https://learn.microsoft.com/azure/quotas/view-quotas) for the VM sizes in your node pools. New subscriptions often need an increase.
-- **Cost:** NKP does not fit within the free tier; the AKS node pool VMs, managed disks, and load balancer all bill from day one.
+- **Quotas:** confirm your subscription has enough [regional vCPU quota](https://learn.microsoft.com/azure/quotas/view-quotas) for the VM sizes in your node pools. New subscriptions often need an increase, and NKP will not warn you before you hit the limit.
+- **Cost:** NKP does not fit within the free tier. The node-pool VMs, managed disks, and load balancer all bill from the moment they are created.
 
 ### Credentials
 
-`nic` requires your subscription ID and resolves everything else through the standard Azure credential chain ([`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/azure-sdk-authentication)), which tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
+`nic` needs one thing from you directly — your **subscription ID** — and resolves everything else through the standard Azure credential chain, [`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/azure-sdk-authentication). It tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
 
-The simplest path is the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli):
+For most people the simplest path is the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli):
 
 ```bash
 az login
-az account show --query id --output tsv   # this is your subscription ID
+az account show --query id --output tsv   # this prints your subscription ID
 ```
 
-For automation, create a service principal instead and use its client/tenant/secret:
+:::tip
+For automation or CI, create a service principal instead and use its client, tenant, and secret values (the first branch of the credential chain):
 
 ```bash
 az ad sp create-for-rbac --name nic-deploy --role Contributor \
   --scopes /subscriptions/<subscription-id>
 ```
+:::
 
 ### Install nic
 
@@ -73,17 +77,23 @@ AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000  # az account show --
 # AZURE_CLIENT_SECRET=...
 ```
 
-`nic` exports `AZURE_SUBSCRIPTION_ID` to the underlying OpenTofu run as `ARM_SUBSCRIPTION_ID`; you don't need to set the `ARM_*` variables yourself.
+:::note
+You only ever set `AZURE_SUBSCRIPTION_ID`. `nic` passes it through to the underlying OpenTofu run as `ARM_SUBSCRIPTION_ID`, so you do not need to set any `ARM_*` variables yourself.
+:::
 
 ## Cost considerations
 
 A NKP deployment provisions several Azure services that bill from day one. Check the [Azure pricing calculator](https://azure.microsoft.com/pricing/calculator/) for current rates in your region.
 
-- **[AKS control plane](https://azure.microsoft.com/pricing/details/kubernetes-service/):** the `Free` SKU tier (the example default) has no control-plane charge; `Standard` adds a per-cluster hourly fee for the uptime SLA.
-- **[Virtual machines](https://azure.microsoft.com/pricing/details/virtual-machines/linux/)** in your node pools: per-hour VM cost for each running node.
-- **[Managed disks](https://azure.microsoft.com/pricing/details/managed-disks/):** OS disks on each node plus any `managed-csi` persistent volumes.
+- **[AKS control plane](https://azure.microsoft.com/pricing/details/kubernetes-service/):** the `Free` SKU tier (the default) has no control-plane charge; switching `sku_tier` to `Standard` adds a per-cluster hourly fee for an uptime SLA.
+- **[Virtual machines](https://azure.microsoft.com/pricing/details/virtual-machines/linux/)** in your node pools: per-hour cost for each running node.
+- **[Managed disks](https://azure.microsoft.com/pricing/details/managed-disks/):** an OS disk on each node (128 GB by default) plus any `managed-csi` persistent volumes your workloads request.
 - **[Load balancer](https://azure.microsoft.com/pricing/details/load-balancer/):** the Standard Load Balancer AKS uses for ingress, plus a public IP.
 - **[Bandwidth](https://azure.microsoft.com/pricing/details/bandwidth/):** outbound data transfer.
+
+:::note[Shared state storage]
+`nic` also creates a small, cheap Terraform state backend — a resource group `nic-tfstate-rg` with a storage account and a `tfstate` container. It is **shared across every cluster you deploy in the subscription** and is deliberately **not removed by `nic destroy`**. Delete it by hand only once you are done with all clusters.
+:::
 
 ## Configuration
 
@@ -118,10 +128,11 @@ git_repository:
 
 cluster:
   azure:
-    region: eastus                # an AKS-supported region
+    region: eastus                # an AKS-supported region (required)
     kubernetes_version: "1.34"
-    node_groups:
-      # Exactly one node group must be mode: System (it hosts cluster services).
+    node_groups:                  # at least one pool is required
+      # AKS needs one System node pool for cluster services. Mark it explicitly:
+      # nic defaults an unset `mode` to User, so without this you get no System pool.
       system:
         instance: Standard_D4_v3
         min_nodes: 1
@@ -133,7 +144,11 @@ cluster:
         max_nodes: 5
 ```
 
-By default `nic` creates a resource group named `<project_name>-rg`. Set `resource_group_name` to deploy into one you manage.
+:::warning
+Give exactly one node pool `mode: System`. `nic` does not add one for you and defaults an omitted `mode` to `User`; a config with no System pool passes `nic validate` but AKS rejects it at deploy time.
+:::
+
+By default `nic` creates a resource group named `<project_name>-rg`. Set `resource_group_name` to deploy into one you already manage.
 
 For the full schema (custom networking, private clusters, `sku_tier`, Node Auto Provisioning, authorized IP ranges), see the [Azure provider reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#25-clusterazure-aks).
 
@@ -141,7 +156,7 @@ For the full schema (custom networking, private clusters, `sku_tier`, Node Auto 
 
 Follow [Deploy a cluster](/docs/how-tos/deploy-cluster) to deploy and verify. The first deployment takes at least 20 minutes as AKS provisions the control plane and node pools, followed by ArgoCD syncing foundational services.
 
-Azure does not write a kubeconfig to a cache path. Fetch a cluster-admin kubeconfig with `nic` and point `kubectl` at it:
+Azure does not write a kubeconfig to a local cache path. Fetch a cluster-admin kubeconfig with `nic` and point `kubectl` at it:
 
 ```bash
 nic kubeconfig -f <config-file> -o kubeconfig
@@ -164,13 +179,7 @@ Changing `region`, `project_name`, or `resource_group_name` triggers destructive
 
 ## Upgrade Kubernetes version
 
-AKS upgrades one minor version at a time — you cannot skip versions or downgrade. To go from 1.32 to 1.34 you must upgrade twice:
-
-```
-1.32 → 1.33 → 1.34
-```
-
-Set `kubernetes_version` under `cluster.azure` in your config:
+To upgrade, set `kubernetes_version` under `cluster.azure` and re-deploy:
 
 ```yaml
 cluster:
@@ -178,7 +187,7 @@ cluster:
     kubernetes_version: "1.33"   # was "1.32"
 ```
 
-AKS upgrades the control plane first, then rolls each node pool one node at a time — surging in a new node, waiting for it to become Ready, then draining and removing the old one. Plan for 20–40 minutes total depending on the number of node pools.
+`nic` passes the version straight through to AKS and does not sequence the upgrade itself — the rules come from AKS. AKS upgrades **one minor version at a time** and does not allow skipping versions or downgrading, so going from 1.32 to 1.34 means upgrading twice (`1.32 → 1.33 → 1.34`). AKS upgrades the control plane first, then rolls each node pool a node at a time — surging in a new node, waiting for it to become Ready, then draining and removing the old one. Plan for 20–40 minutes depending on the number of node pools.
 
 See [Upgrade Kubernetes version](/docs/how-tos/upgrade-kubernetes) for the upgrade commands and post-upgrade verification steps.
 
@@ -186,6 +195,8 @@ See [Upgrade Kubernetes version](/docs/how-tos/upgrade-kubernetes) for the upgra
 
 Run the destroy commands as described in [Destroy a cluster](/docs/how-tos/destroy-cluster).
 
-`nic destroy` removes the AKS cluster, its node pools, the load balancer, and (when `nic` created it) the `<project_name>-rg` resource group. If a resource fails to delete, remove it manually in the Azure portal before retrying with `--force`.
+`nic destroy` removes the AKS cluster, its node pools, the load balancer, and (when `nic` created it) the `<project_name>-rg` resource group. It does **not** remove the shared `nic-tfstate-rg` state backend — remove that by hand once you are finished with every cluster in the subscription.
 
-Always confirm in the Azure portal that no orphan resources remain — VMs, managed disks, public IPs, and load balancers can keep billing if they're left behind.
+:::warning
+Always confirm in the Azure portal that no orphan resources remain. VMs, managed disks, public IPs, and load balancers keep billing if they are left behind. If a resource fails to delete, remove it manually before retrying with `--force`.
+:::

--- a/docs/docs/how-tos/providers/azure.mdx
+++ b/docs/docs/how-tos/providers/azure.mdx
@@ -9,7 +9,7 @@ description: End-to-end how-to for deploying, updating, and destroying NKP on Az
 This guide walks you through a deployment from end to end — from an empty subscription to a running cluster you can manage and tear down. If you have deployed NKP on AWS, the flow will feel familiar: the differences are mostly in how you authenticate and in a few Azure-specific fields.
 
 :::warning[A cloud deployment is not free]
-Deploying NKP on Azure provisions real, billed infrastructure — it is **not** a free-tier workload. The AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer all bill from the moment they are created, and the smallest working cluster needs multi-GB VMs (the example uses 4 vCPU / 16 GB nodes) that are well beyond free-tier sizes. You can create a free Azure account and its 30-day credit can fund a short evaluation, but to try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
+A NKP deployment on Azure will **not** fall within free-tier usage — the AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer lead to additional charges, and the smallest working cluster needs multi-GB VMs well beyond free-tier sizes. We recommend reviewing the [Azure pricing calculator](https://azure.microsoft.com/pricing/calculator/), or checking with your cloud administrator, before you deploy. A free Azure account's 30-day credit can fund a short evaluation, but to try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
 :::
 
 ## What your team gets
@@ -31,11 +31,11 @@ You will need an Azure subscription you can deploy into. A [free Azure account](
 
 - **Region:** pick a [region where AKS is available](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=kubernetes-service). The example uses `eastus`.
 - **Quotas:** confirm your subscription has enough [regional vCPU quota](https://learn.microsoft.com/azure/quotas/view-quotas) for the VM sizes in your node pools. New subscriptions often need an increase, and NKP will not warn you before you hit the limit.
-- **Cost:** the AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer bill from the moment they are created. See [Cost considerations](#cost-considerations) for the full list.
+- **Cost:** NKP is a billed workload; see [Cost considerations](#cost-considerations) for the full breakdown of what charges.
 
 ### Credentials
 
-`nic` needs one thing from you directly — your **subscription ID** — and resolves everything else through the standard Azure credential chain, [`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/azure-sdk-authentication). It tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
+`nic` needs one thing from you directly — your **subscription ID** — and resolves everything else through the standard Azure credential chain, [`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/sdk/authentication/authentication-overview). It tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
 
 For most people the simplest path is the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli):
 
@@ -135,8 +135,7 @@ cluster:
     region: eastus                # an AKS-supported region (required)
     kubernetes_version: "1.34"
     node_groups:                  # at least one pool is required
-      # AKS needs one System node pool for cluster services. Mark it explicitly:
-      # nic defaults an unset `mode` to User, so without this you get no System pool.
+      # One pool must be mode: System (see the warning below).
       system:
         instance: Standard_D4_v3
         min_nodes: 1

--- a/docs/docs/how-tos/providers/azure.mdx
+++ b/docs/docs/how-tos/providers/azure.mdx
@@ -8,6 +8,10 @@ description: End-to-end how-to for deploying, updating, and destroying NKP on Az
 
 This guide walks you through a deployment from end to end — from an empty subscription to a running cluster you can manage and tear down. If you have deployed NKP on AWS, the flow will feel familiar: the differences are mostly in how you authenticate and in a few Azure-specific fields.
 
+:::warning[A cloud deployment is not free]
+Deploying NKP on Azure provisions real, billed infrastructure — it is **not** a free-tier workload. The AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer all bill from the moment they are created, and the smallest working cluster needs multi-GB VMs (the example uses 4 vCPU / 16 GB nodes) that are well beyond free-tier sizes. You can create a free Azure account and its 30-day credit can fund a short evaluation, but to try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
+:::
+
 ## What your team gets
 
 When `nic deploy` finishes, your team will have all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
@@ -23,11 +27,11 @@ Shared read-write-many storage (the Longhorn or EFS equivalent) is not yet wired
 
 ### Azure subscription
 
-You will need access to an Azure subscription you can deploy into. If you do not have one, [create a free account](https://azure.microsoft.com/free/).
+You will need an Azure subscription you can deploy into. A [free Azure account](https://azure.microsoft.com/free/) is enough to create one and comes with a 30-day credit, but keep the note above in mind — NKP itself is a billed workload, not a free-tier one.
 
 - **Region:** pick a [region where AKS is available](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=kubernetes-service). The example uses `eastus`.
 - **Quotas:** confirm your subscription has enough [regional vCPU quota](https://learn.microsoft.com/azure/quotas/view-quotas) for the VM sizes in your node pools. New subscriptions often need an increase, and NKP will not warn you before you hit the limit.
-- **Cost:** NKP does not fit within the free tier. The node-pool VMs, managed disks, and load balancer all bill from the moment they are created.
+- **Cost:** the AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer bill from the moment they are created. See [Cost considerations](#cost-considerations) for the full list.
 
 ### Credentials
 

--- a/docs/docs/how-tos/providers/azure.mdx
+++ b/docs/docs/how-tos/providers/azure.mdx
@@ -6,10 +6,10 @@ description: End-to-end how-to for deploying, updating, and destroying NKP on Az
 
 [Microsoft Azure](https://azure.microsoft.com/) is Microsoft's public cloud. NKP deploys onto it as a managed [AKS (Azure Kubernetes Service)](https://learn.microsoft.com/azure/aks/) cluster, so Azure runs and upgrades the Kubernetes control plane for you while `nic` (the Nebari Infrastructure Core CLI) provisions the cluster, the node pools, and the supporting infrastructure.
 
-This guide walks you through a deployment from end to end — from an empty subscription to a running cluster you can manage and tear down. If you have deployed NKP on AWS, the flow will feel familiar: the differences are mostly in how you authenticate and in a few Azure-specific fields.
+This guide walks you through a deployment from end to end: from an empty subscription to a running cluster you can manage and tear down. If you have deployed NKP on AWS, the flow will feel familiar: the differences are mostly in how you authenticate and in a few Azure-specific fields.
 
 :::warning[A cloud deployment is not free]
-A NKP deployment on Azure will **not** fall within free-tier usage — the AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer lead to additional charges, and the smallest working cluster needs multi-GB VMs well beyond free-tier sizes. We recommend reviewing the [Azure pricing calculator](https://azure.microsoft.com/pricing/calculator/), or checking with your cloud administrator, before you deploy. A free Azure account's 30-day credit can fund a short evaluation, but to try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
+A NKP deployment on Azure will **not** fall within free-tier usage. The AKS control plane is free on the default `Free` SKU, but the node VMs, managed disks, and load balancer lead to additional charges, and the smallest working cluster needs multi-GB VMs well beyond free-tier sizes. We recommend reviewing the [Azure pricing calculator](https://azure.microsoft.com/pricing/calculator/), or checking with your cloud administrator, before you deploy. A free Azure account's 30-day credit can fund a short evaluation, but to try NKP at no cost, deploy locally with the [Local (kind)](/docs/how-tos/providers/local) provider instead.
 :::
 
 ## What your team gets
@@ -27,7 +27,7 @@ Shared read-write-many storage (the Longhorn or EFS equivalent) is not yet wired
 
 ### Azure subscription
 
-You will need an Azure subscription you can deploy into. A [free Azure account](https://azure.microsoft.com/free/) is enough to create one and comes with a 30-day credit, but keep the note above in mind — NKP itself is a billed workload, not a free-tier one.
+You will need an Azure subscription you can deploy into. A [free Azure account](https://azure.microsoft.com/free/) is enough to create one and comes with a 30-day credit, but keep the note above in mind: NKP itself is a billed workload, not a free-tier one.
 
 - **Region:** pick a [region where AKS is available](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=kubernetes-service). The example uses `eastus`.
 - **Quotas:** confirm your subscription has enough [regional vCPU quota](https://learn.microsoft.com/azure/quotas/view-quotas) for the VM sizes in your node pools. New subscriptions often need an increase, and NKP will not warn you before you hit the limit.
@@ -35,7 +35,7 @@ You will need an Azure subscription you can deploy into. A [free Azure account](
 
 ### Credentials
 
-`nic` needs one thing from you directly — your **subscription ID** — and resolves everything else through the standard Azure credential chain, [`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/sdk/authentication/authentication-overview). It tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
+`nic` needs one thing from you directly, your **subscription ID**, and resolves everything else through the standard Azure credential chain, [`DefaultAzureCredential`](https://learn.microsoft.com/azure/developer/go/sdk/authentication/authentication-overview). It tries, in order: environment variables (`AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_CLIENT_SECRET`), workload identity, managed identity, and finally the Azure CLI.
 
 For most people the simplest path is the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli):
 
@@ -96,7 +96,7 @@ A NKP deployment provisions several Azure services that bill from day one. Check
 - **[Bandwidth](https://azure.microsoft.com/pricing/details/bandwidth/):** outbound data transfer.
 
 :::note[Shared state storage]
-`nic` also creates a small, cheap Terraform state backend — a resource group `nic-tfstate-rg` with a storage account and a `tfstate` container. It is **shared across every cluster you deploy in the subscription** and is deliberately **not removed by `nic destroy`**. Delete it by hand only once you are done with all clusters.
+`nic` also creates a small, cheap Terraform state backend: a resource group `nic-tfstate-rg` with a storage account and a `tfstate` container. It is **shared across every cluster you deploy in the subscription** and is deliberately **not removed by `nic destroy`**. Delete it by hand only once you are done with all clusters.
 :::
 
 ## Configuration
@@ -190,7 +190,7 @@ cluster:
     kubernetes_version: "1.33"   # was "1.32"
 ```
 
-`nic` passes the version straight through to AKS and does not sequence the upgrade itself — the rules come from AKS. AKS upgrades **one minor version at a time** and does not allow skipping versions or downgrading, so going from 1.32 to 1.34 means upgrading twice (`1.32 → 1.33 → 1.34`). AKS upgrades the control plane first, then rolls each node pool a node at a time — surging in a new node, waiting for it to become Ready, then draining and removing the old one. Plan for 20–40 minutes depending on the number of node pools.
+`nic` passes the version straight through to AKS and does not sequence the upgrade itself; the rules come from AKS. AKS upgrades **one minor version at a time** and does not allow skipping versions or downgrading, so going from 1.32 to 1.34 means upgrading twice (`1.32 → 1.33 → 1.34`). AKS upgrades the control plane first, then rolls each node pool a node at a time: surging in a new node, waiting for it to become Ready, then draining and removing the old one. Plan for 20–40 minutes depending on the number of node pools.
 
 See [Upgrade Kubernetes version](/docs/how-tos/upgrade-kubernetes) for the upgrade commands and post-upgrade verification steps.
 
@@ -198,7 +198,7 @@ See [Upgrade Kubernetes version](/docs/how-tos/upgrade-kubernetes) for the upgra
 
 Run the destroy commands as described in [Destroy a cluster](/docs/how-tos/destroy-cluster).
 
-`nic destroy` removes the AKS cluster, its node pools, the load balancer, and (when `nic` created it) the `<project_name>-rg` resource group. It does **not** remove the shared `nic-tfstate-rg` state backend — remove that by hand once you are finished with every cluster in the subscription.
+`nic destroy` removes the AKS cluster, its node pools, the load balancer, and (when `nic` created it) the `<project_name>-rg` resource group. It does **not** remove the shared `nic-tfstate-rg` state backend; remove that by hand once you are finished with every cluster in the subscription.
 
 :::warning
 Always confirm in the Azure portal that no orphan resources remain. VMs, managed disks, public IPs, and load balancers keep billing if they are left behind. If a resource fails to delete, remove it manually before retrying with `--force`.

--- a/docs/docs/how-tos/providers/azure.mdx
+++ b/docs/docs/how-tos/providers/azure.mdx
@@ -148,7 +148,7 @@ cluster:
 ```
 
 :::warning
-Give exactly one node pool `mode: System`. `nic` does not add one for you and defaults an omitted `mode` to `User`; a config with no System pool passes `nic validate` but AKS rejects it at deploy time.
+AKS needs one **System** node pool to host cluster services, and `nic` does not add one for you. Set `mode: System` on exactly one of your pools; a pool with no `mode` defaults to `User`. A config with no System pool still passes `nic validate`, but AKS rejects it when it provisions the cluster.
 :::
 
 By default `nic` creates a resource group named `<project_name>-rg`. Set `resource_group_name` to deploy into one you already manage.

--- a/docs/docs/how-tos/providers/index.mdx
+++ b/docs/docs/how-tos/providers/index.mdx
@@ -6,12 +6,12 @@ description: Provider support matrix for NKP, covering supported and planned dep
 
 # Providers
 
-NKP supports two production deploy targets today. The other providers are partially built but not yet usable; their pages describe the current state and how to follow progress.
+NKP supports several deploy targets. Hetzner and AWS are the recommended production targets, Azure is supported, and Local (kind) runs on your own machine for development and testing. GCP is still being built; its page describes the current state and how to follow progress.
 
 | Provider | Status |
 | --- | --- |
 | [Hetzner](/docs/how-tos/providers/hetzner) | ✅ Supported (recommended starter) |
 | [AWS](/docs/how-tos/providers/aws) | ✅ Supported |
+| [Microsoft Azure](/docs/how-tos/providers/azure) | ✅ Supported |
+| [Local (kind)](/docs/how-tos/providers/local) | ✅ Supported (development/testing) |
 | [Google Cloud Platform (GCP)](/docs/how-tos/providers/gcp) | 🚧 Planned |
-| [Microsoft Azure](/docs/how-tos/providers/azure) | 🚧 Planned |
-| [Local (K3s)](/docs/how-tos/providers/local) | 🚧 Planned |

--- a/docs/docs/how-tos/providers/local.mdx
+++ b/docs/docs/how-tos/providers/local.mdx
@@ -4,7 +4,7 @@ slug: /how-tos/providers/local
 description: Run NKP locally on kind (Kubernetes in Docker) for development and testing, with nic.
 ---
 
-NKP supports a **local mode** that lets you run the whole platform on a single machine — a laptop, a workstation, or a VM — without a cloud account. It is meant as a way to develop against NKP, preview its functionality, or debug a configuration with a quick feedback loop. We do not recommend it for production: anything a cloud provides (managed Kubernetes, cloud load balancers, managed storage) is stood up locally instead, so it will not match a real deployment one-for-one.
+NKP supports a **local mode** that lets you run the whole platform on a single machine (a laptop, a workstation, or a VM) without a cloud account. It is meant as a way to develop against NKP, preview its functionality, or debug a configuration with a quick feedback loop. We do not recommend it for production: anything a cloud provides (managed Kubernetes, cloud load balancers, managed storage) is stood up locally instead, so it will not match a real deployment one-for-one.
 
 This guide walks you through running NKP locally with `nic` (the Nebari Infrastructure Core CLI) on [kind](https://kind.sigs.k8s.io/).
 
@@ -12,7 +12,7 @@ This guide walks you through running NKP locally with `nic` (the Nebari Infrastr
 
 [kind](https://kind.sigs.k8s.io/) ("Kubernetes in Docker") runs a Kubernetes cluster inside a container on your machine. It was built for testing Kubernetes itself, but it is also an excellent target for local development: it starts fast, needs no cloud resources, and tears down cleanly.
 
-`nic` **embeds** the kind library directly, so you do **not** install the `kind` CLI separately — `nic` drives your container runtime for you. The local provider stands up a single-node cluster and then installs the same NKP services you would get on a cloud provider.
+`nic` **embeds** the kind library directly, so you do **not** install the `kind` CLI separately; `nic` drives your container runtime for you. The local provider stands up a single-node cluster and then installs the same NKP services you would get on a cloud provider.
 
 ## What your team gets
 
@@ -26,7 +26,7 @@ When `nic deploy` finishes, you will have a local NKP cluster with all [standard
 
 ### A container runtime
 
-kind runs Kubernetes inside a container, so you need **Docker or Podman** installed and running — `nic` auto-detects whichever you have. That is the only external dependency; there is no `kind` binary to install.
+kind runs Kubernetes inside a container, so you need **Docker or Podman** installed and running; `nic` auto-detects whichever you have. That is the only external dependency; there is no `kind` binary to install.
 
 :::tip
 This mode runs everything on your machine, so give the container runtime some headroom. A few CPU cores and several GB of RAM is a comfortable starting point (roughly 4 CPU / 8 GB); a busy cluster with many services will want more. This is a practical recommendation, not a hard requirement.
@@ -38,7 +38,7 @@ Follow the [Install NIC](/docs/get-started/install) guide to download and instal
 
 ### GitOps repository (optional)
 
-Unlike the cloud providers, local deployments do **not** require a remote GitOps repository. If you omit the `git_repository` section, `nic` auto-creates and mounts a local one at `~/.nic/gitops/<project_name>` — the zero-configuration path, and the one we recommend while developing. To point at a specific repository instead, see the options in the [starter config](#configuration) below.
+Unlike the cloud providers, local deployments do **not** require a remote GitOps repository. If you omit the `git_repository` section, `nic` auto-creates and mounts a local one at `~/.nic/gitops/<project_name>`, the zero-configuration path and the one we recommend while developing. To point at a specific repository instead, see the options in the [starter config](#configuration) below.
 
 ## Configuration
 
@@ -54,7 +54,7 @@ curl -O https://raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/
 In later steps, `<config-file>` refers to this local copy (`local-config.yaml`).
 :::
 
-A local config needs very little — the provider fills in sensible defaults, so a minimal file is enough to get started:
+A local config needs very little: the provider fills in sensible defaults, so a minimal file is enough to get started:
 
 ```yaml
 project_name: my-nebari-local
@@ -66,7 +66,7 @@ cluster:
   local: {}                       # kind defaults; no region, no node groups
 ```
 
-There are no node groups, no region, and no `kubernetes_version` field: kind runs a single node, and its Kubernetes version comes from the kind `node_image`. The whole `cluster.local` block is optional and only exists to tune kind — the node image, extra host mounts, the HTTPS port (default `443`), and the MetalLB address pool.
+There are no node groups, no region, and no `kubernetes_version` field: kind runs a single node, and its Kubernetes version comes from the kind `node_image`. The whole `cluster.local` block is optional and only exists to tune kind: the node image, extra host mounts, the HTTPS port (default `443`), and the MetalLB address pool.
 
 For GitOps you have three options: omit `git_repository` for the auto-created local repo (recommended for development), point `git_repository.url` at a local `file://` path, or use a remote repository. For the full schema, see the [Local provider reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#23-clusterlocal-kind-for-development) and the dedicated [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md).
 
@@ -118,4 +118,4 @@ Run the destroy commands as described in [Destroy](/docs/how-tos/deploy#destroy)
 nic destroy -f <config-file>
 ```
 
-`nic destroy` deletes the kind cluster and its container. Because everything runs locally, there are no cloud resources to reconcile afterward — the only thing that may linger is the shared kind Docker network, which kind removes once no kind clusters remain.
+`nic destroy` deletes the kind cluster and its container. Because everything runs locally, there are no cloud resources to reconcile afterward; the only thing that may linger is the shared kind Docker network, which kind removes once no kind clusters remain.

--- a/docs/docs/how-tos/providers/local.mdx
+++ b/docs/docs/how-tos/providers/local.mdx
@@ -4,25 +4,33 @@ slug: /how-tos/providers/local
 description: Run NKP locally on kind (Kubernetes in Docker) for development and testing, with nic.
 ---
 
-This guide walks through running NKP locally with `nic` (the Nebari Infrastructure Core CLI) on [kind](https://kind.sigs.k8s.io/) — Kubernetes running inside a container on your machine.
+NKP supports a **local mode** that lets you run the whole platform on a single machine — a laptop, a workstation, or a VM — without a cloud account. It is meant as a way to develop against NKP, preview its functionality, or debug a configuration with a quick feedback loop. We do not recommend it for production: anything a cloud provides (managed Kubernetes, cloud load balancers, managed storage) is stood up locally instead, so it will not match a real deployment one-for-one.
 
-The local provider is for **development and testing**, not production. It is the quickest way to try NKP end to end without a cloud account: no credentials, no cloud bill, and a full teardown that leaves nothing behind.
+This guide walks you through running NKP locally with `nic` (the Nebari Infrastructure Core CLI) on [kind](https://kind.sigs.k8s.io/).
+
+## What is kind?
+
+[kind](https://kind.sigs.k8s.io/) ("Kubernetes in Docker") runs a Kubernetes cluster inside a container on your machine. It was built for testing Kubernetes itself, but it is also an excellent target for local development: it starts fast, needs no cloud resources, and tears down cleanly.
+
+`nic` **embeds** the kind library directly, so you do **not** install the `kind` CLI separately — `nic` drives your container runtime for you. The local provider stands up a single-node cluster and then installs the same NKP services you would get on a cloud provider.
 
 ## What your team gets
 
-When `nic deploy` finishes, you'll have a local NKP cluster with all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
+When `nic deploy` finishes, you will have a local NKP cluster with all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
 
 - **A single-node kind cluster** running in your local container runtime.
-- **Local-path storage** (the built-in `standard` StorageClass) for persistent volumes.
+- **Local-path storage** (kind's built-in `standard` StorageClass) for persistent volumes.
 - **A routable gateway IP** via MetalLB, which `nic` configures automatically from your container network so services are reachable from the host.
 
 ## Prerequisites
 
 ### A container runtime
 
-kind runs Kubernetes inside a container, so you need **Docker or Podman** installed and running. `nic` embeds kind, so you do **not** need to install the `kind` CLI separately — it drives your container runtime directly.
+kind runs Kubernetes inside a container, so you need **Docker or Podman** installed and running — `nic` auto-detects whichever you have. That is the only external dependency; there is no `kind` binary to install.
 
-Your machine needs enough headroom for the cluster and the NKP services; treat 4 CPU / 8 GB RAM as a practical floor.
+:::tip
+This mode runs everything on your machine, so give the container runtime some headroom. A few CPU cores and several GB of RAM is a comfortable starting point (roughly 4 CPU / 8 GB); a busy cluster with many services will want more. This is a practical recommendation, not a hard requirement.
+:::
 
 ### Install nic
 
@@ -30,7 +38,7 @@ Follow the [Install NIC](/docs/get-started/install) guide to download and instal
 
 ### GitOps repository (optional)
 
-Unlike the cloud providers, local deployments do **not** require a remote GitOps repository. If you omit the `git_repository` section, `nic` auto-creates and mounts a local one at `~/.nic/gitops/<project_name>`, which is ideal for development. To use a specific repository instead, see the options in the [starter config](#configuration) below.
+Unlike the cloud providers, local deployments do **not** require a remote GitOps repository. If you omit the `git_repository` section, `nic` auto-creates and mounts a local one at `~/.nic/gitops/<project_name>` — the zero-configuration path, and the one we recommend while developing. To point at a specific repository instead, see the options in the [starter config](#configuration) below.
 
 ## Configuration
 
@@ -46,25 +54,33 @@ curl -O https://raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/
 In later steps, `<config-file>` refers to this local copy (`local-config.yaml`).
 :::
 
-A minimal local config needs very little — the local provider fills in sensible defaults:
+A local config needs very little — the provider fills in sensible defaults, so a minimal file is enough to get started:
 
 ```yaml
 project_name: my-nebari-local
-domain: nebari.local              # resolved to the gateway IP; see Access below
+domain: nebari.local              # not real DNS; mapped to the gateway IP below
 certificate:
   type: selfsigned                # local deployments use a self-signed certificate
 
 cluster:
-  local: {}                       # kind defaults; no region or node groups
+  local: {}                       # kind defaults; no region, no node groups
 ```
 
-There are no node groups, no region, and no `kubernetes_version` field — kind runs a single node, and its Kubernetes version comes from the kind `node_image`. The `cluster.local` block is optional and lets you tune the kind node image, extra host mounts, the HTTPS port (default `443`), and the MetalLB address pool.
+There are no node groups, no region, and no `kubernetes_version` field: kind runs a single node, and its Kubernetes version comes from the kind `node_image`. The whole `cluster.local` block is optional and only exists to tune kind — the node image, extra host mounts, the HTTPS port (default `443`), and the MetalLB address pool.
 
-For GitOps, you have three options: omit `git_repository` for the auto-created local repo (recommended for development), point `git_repository.url` at a `file://` path, or use a remote repository. For the full schema, see the [Local provider reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#23-clusterlocal-kind-for-development) and the dedicated [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md).
+For GitOps you have three options: omit `git_repository` for the auto-created local repo (recommended for development), point `git_repository.url` at a local `file://` path, or use a remote repository. For the full schema, see the [Local provider reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#23-clusterlocal-kind-for-development) and the dedicated [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md).
+
+:::note
+Unknown keys inside `cluster.local` are silently accepted rather than rejected, so a typo (for example `node_iamge`) will pass `nic validate` and simply be ignored. Double-check field names against the reference if a setting does not seem to take effect.
+:::
 
 ## Deploy
 
 Run the deploy commands as described in [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) in the deploy lifecycle guide. The first deployment pulls the kind node image and creates the cluster, then ArgoCD syncs the foundational services.
+
+:::note
+kind settings such as the node image and extra mounts are applied when the cluster is **created**. If the cluster already exists, `nic deploy` reuses it and those settings are not re-applied until you destroy and recreate it.
+:::
 
 ## Verify
 
@@ -74,17 +90,21 @@ kind merges the cluster into your kubeconfig under the context `kind-<project_na
 kubectl config use-context kind-<project_name>
 ```
 
-You can also fetch a standalone kubeconfig with `nic kubeconfig -f <config-file> -o kubeconfig`. Then follow the [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) steps to check the cluster and ArgoCD applications.
+You can also write a standalone kubeconfig with `nic kubeconfig -f <config-file> -o kubeconfig`. Then follow the [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) steps to check the cluster and its ArgoCD applications.
 
 ## Access
 
-`domain` (for example `nebari.local`) is not a real DNS name, so map it to the gateway's LoadBalancer IP on your host. Find the IP that MetalLB assigned to the gateway service, then add it to `/etc/hosts`:
+`domain` (for example `nebari.local`) is not a real DNS name, so you map it to the gateway's LoadBalancer IP on your own machine. Find the IP that MetalLB assigned to the gateway service, then add it to your `/etc/hosts`:
 
 ```bash
 # <gateway-ip>  nebari.local
 ```
 
-Because the certificate is self-signed, your browser will warn on first visit — accept the exception to continue. The [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md) covers the gateway service name, port overrides, and networking in detail.
+:::tip
+Because the certificate is self-signed, your browser will warn the first time you visit. You can safely accept the exception for a local cluster. If the browser refuses to show an "accept the risk" option, type <code>thisisunsafe</code> while the warning page is focused in Chrome, or set `network.stricttransportsecurity.preloadlist` to `false` in Firefox's `about:config`.
+:::
+
+The [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md) covers the gateway service name, port overrides, and networking in more detail.
 
 ## First sign-in
 
@@ -94,4 +114,8 @@ See [Keycloak authentication](/docs/how-tos/keycloak-auth) for first sign-in.
 
 Run the destroy commands as described in [Destroy](/docs/how-tos/deploy#destroy) in the deploy lifecycle guide.
 
-`nic destroy` deletes the kind cluster and its container. Because everything runs locally, there are no cloud resources to reconcile afterward.
+```bash
+nic destroy -f <config-file>
+```
+
+`nic destroy` deletes the kind cluster and its container. Because everything runs locally, there are no cloud resources to reconcile afterward — the only thing that may linger is the shared kind Docker network, which kind removes once no kind clusters remain.

--- a/docs/docs/how-tos/providers/local.mdx
+++ b/docs/docs/how-tos/providers/local.mdx
@@ -106,6 +106,45 @@ Because the certificate is self-signed, your browser will warn the first time yo
 
 The [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md) covers the gateway service name, port overrides, and networking in more detail.
 
+## Use a locally-trusted certificate (optional)
+
+The self-signed certificate is fine for a quick look, but you can avoid the browser warning entirely with [mkcert](https://github.com/FiloSottile/mkcert). mkcert installs a local certificate authority (CA) that your browser trusts and then issues certificates signed by it, so NKP serves a certificate the browser accepts and `https://nebari.local` gets a normal padlock.
+
+First, [install mkcert](https://github.com/FiloSottile/mkcert#installation) and trust its local CA (a one-time step):
+
+```bash
+mkcert -install
+```
+
+Then generate a certificate that covers your domain. NKP serves some services as subdomains (`keycloak.<domain>`, `argocd.<domain>`), so include a wildcard alongside the apex; a wildcard on its own does not match the bare `nebari.local`:
+
+```bash
+mkcert nebari.local "*.nebari.local"
+# writes nebari.local+1.pem and nebari.local+1-key.pem in the current directory
+```
+
+Point your config at those files with `certificate.type: existing`, using absolute paths:
+
+```yaml
+project_name: my-nebari-local
+domain: nebari.local
+
+certificate:
+  type: existing
+  files:
+    cert_file: /absolute/path/to/nebari.local+1.pem
+    key_file: /absolute/path/to/nebari.local+1-key.pem
+
+cluster:
+  local: {}
+```
+
+Deploy (or re-deploy) with this config. `nic` reads the two files from your machine, creates the gateway TLS secret in the cluster, and the gateway serves your mkcert certificate. Because you trusted the local CA with `mkcert -install`, `nebari.local` and its subdomains now load without a warning.
+
+:::note
+Make sure `nebari.local` resolves to the gateway IP first (see [Access](#access)) so the certificate matches the address you visit. Re-running `nic deploy` with updated files refreshes the certificate in place. For the full set of certificate options (environment variables, a pre-created secret, non-local domains), see the upstream [custom TLS certificate guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/custom-tls-certificate.md).
+:::
+
 ## First sign-in
 
 See [Keycloak authentication](/docs/how-tos/keycloak-auth) for first sign-in.

--- a/docs/docs/how-tos/providers/local.mdx
+++ b/docs/docs/how-tos/providers/local.mdx
@@ -1,11 +1,97 @@
 ---
-title: Local (K3s)
+title: Local (kind)
 slug: /how-tos/providers/local
-description: Planned local K3s NKP support for development and testing.
+description: Run NKP locally on kind (Kubernetes in Docker) for development and testing, with nic.
 ---
 
-import PlannedProvider from '@site/src/components/PlannedProvider';
+This guide walks through running NKP locally with `nic` (the Nebari Infrastructure Core CLI) on [kind](https://kind.sigs.k8s.io/) — Kubernetes running inside a container on your machine.
 
-# Local (K3s)
+The local provider is for **development and testing**, not production. It is the quickest way to try NKP end to end without a cloud account: no credentials, no cloud bill, and a full teardown that leaves nothing behind.
 
-<PlannedProvider stub="local" />
+## What your team gets
+
+When `nic deploy` finishes, you'll have a local NKP cluster with all [standard NKP services](/docs/how-tos/deploy#what-every-deployment-includes) plus:
+
+- **A single-node kind cluster** running in your local container runtime.
+- **Local-path storage** (the built-in `standard` StorageClass) for persistent volumes.
+- **A routable gateway IP** via MetalLB, which `nic` configures automatically from your container network so services are reachable from the host.
+
+## Prerequisites
+
+### A container runtime
+
+kind runs Kubernetes inside a container, so you need **Docker or Podman** installed and running. `nic` embeds kind, so you do **not** need to install the `kind` CLI separately — it drives your container runtime directly.
+
+Your machine needs enough headroom for the cluster and the NKP services; treat 4 CPU / 8 GB RAM as a practical floor.
+
+### Install nic
+
+Follow the [Install NIC](/docs/get-started/install) guide to download and install the `nic` CLI for your platform.
+
+### GitOps repository (optional)
+
+Unlike the cloud providers, local deployments do **not** require a remote GitOps repository. If you omit the `git_repository` section, `nic` auto-creates and mounts a local one at `~/.nic/gitops/<project_name>`, which is ideal for development. To use a specific repository instead, see the options in the [starter config](#configuration) below.
+
+## Configuration
+
+Download the starter config from `nebari-infrastructure-core`:
+
+- **[`local-config.yaml`](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/examples/local-config.yaml)**.
+
+```bash
+curl -O https://raw.githubusercontent.com/nebari-dev/nebari-infrastructure-core/main/examples/local-config.yaml
+```
+
+:::note
+In later steps, `<config-file>` refers to this local copy (`local-config.yaml`).
+:::
+
+A minimal local config needs very little — the local provider fills in sensible defaults:
+
+```yaml
+project_name: my-nebari-local
+domain: nebari.local              # resolved to the gateway IP; see Access below
+certificate:
+  type: selfsigned                # local deployments use a self-signed certificate
+
+cluster:
+  local: {}                       # kind defaults; no region or node groups
+```
+
+There are no node groups, no region, and no `kubernetes_version` field — kind runs a single node, and its Kubernetes version comes from the kind `node_image`. The `cluster.local` block is optional and lets you tune the kind node image, extra host mounts, the HTTPS port (default `443`), and the MetalLB address pool.
+
+For GitOps, you have three options: omit `git_repository` for the auto-created local repo (recommended for development), point `git_repository.url` at a `file://` path, or use a remote repository. For the full schema, see the [Local provider reference](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/design-doc/appendix/16-configuration-reference.md#23-clusterlocal-kind-for-development) and the dedicated [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md).
+
+## Deploy
+
+Run the deploy commands as described in [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) in the deploy lifecycle guide. The first deployment pulls the kind node image and creates the cluster, then ArgoCD syncs the foundational services.
+
+## Verify
+
+kind merges the cluster into your kubeconfig under the context `kind-<project_name>`. Point `kubectl` at it:
+
+```bash
+kubectl config use-context kind-<project_name>
+```
+
+You can also fetch a standalone kubeconfig with `nic kubeconfig -f <config-file> -o kubeconfig`. Then follow the [Deploy and verify](/docs/how-tos/deploy#deploy-and-verify) steps to check the cluster and ArgoCD applications.
+
+## Access
+
+`domain` (for example `nebari.local`) is not a real DNS name, so map it to the gateway's LoadBalancer IP on your host. Find the IP that MetalLB assigned to the gateway service, then add it to `/etc/hosts`:
+
+```bash
+# <gateway-ip>  nebari.local
+```
+
+Because the certificate is self-signed, your browser will warn on first visit — accept the exception to continue. The [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md) covers the gateway service name, port overrides, and networking in detail.
+
+## First sign-in
+
+See [Keycloak authentication](/docs/how-tos/keycloak-auth) for first sign-in.
+
+## Destroy
+
+Run the destroy commands as described in [Destroy](/docs/how-tos/deploy#destroy) in the deploy lifecycle guide.
+
+`nic destroy` deletes the kind cluster and its container. Because everything runs locally, there are no cloud resources to reconcile afterward.

--- a/docs/docs/how-tos/providers/local.mdx
+++ b/docs/docs/how-tos/providers/local.mdx
@@ -94,14 +94,14 @@ You can also write a standalone kubeconfig with `nic kubeconfig -f <config-file>
 
 ## Access
 
-`domain` (for example `nebari.local`) is not a real DNS name, so you map it to the gateway's LoadBalancer IP on your own machine. Find the IP that MetalLB assigned to the gateway service, then add it to your `/etc/hosts`:
+`domain` (for example `nebari.local`) is not a real DNS name, so you map it to the gateway's LoadBalancer IP on your own machine. Find the IP that MetalLB assigned to the gateway service, then add it to your `/etc/hosts` (replace `<gateway-ip>` with that address):
 
-```bash
-# <gateway-ip>  nebari.local
+```
+<gateway-ip>  nebari.local
 ```
 
 :::tip
-Because the certificate is self-signed, your browser will warn the first time you visit. You can safely accept the exception for a local cluster. If the browser refuses to show an "accept the risk" option, type <code>thisisunsafe</code> while the warning page is focused in Chrome, or set `network.stricttransportsecurity.preloadlist` to `false` in Firefox's `about:config`.
+Because the certificate is self-signed, your browser will warn the first time you visit. You can safely accept the exception for a local cluster. If the browser refuses to show an "accept the risk" option, type `thisisunsafe` while the warning page is focused in Chrome, or set `network.stricttransportsecurity.preloadlist` to `false` in Firefox's `about:config`.
 :::
 
 The [local kind development guide](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/docs/local-kind-development.md) covers the gateway service name, port overrides, and networking in more detail.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -59,10 +59,10 @@ module.exports = {
           link: { type: "doc", id: "how-tos/providers/index" },
           items: [
             "how-tos/providers/hetzner",
-            "how-tos/providers/aws", 
+            "how-tos/providers/aws",
             "how-tos/providers/azure",
-            "how-tos/providers/gcp",
             "how-tos/providers/local",
+            "how-tos/providers/gcp",
           ],
         },
       ],


### PR DESCRIPTION
## What this does

Promotes the **Azure** and **Local** providers from planned stubs to full how-to pages, matching the structure of the existing AWS and Hetzner pages. Both providers are implemented and usable on `main` in [nebari-infrastructure-core](https://github.com/nebari-dev/nebari-infrastructure-core), so their pages now document the real deploy/verify/update/destroy lifecycle instead of a "Planned" banner. GCP stays a planned stub.

### Azure (`azure.mdx`)
- Mirrors the AWS managed-cloud page: provisions managed **AKS** via OpenTofu.
- Auth via the standard Azure credential chain (`DefaultAzureCredential`); the only required variable is `AZURE_SUBSCRIPTION_ID` (exported to OpenTofu as `ARM_SUBSCRIPTION_ID`), so `az login` is enough.
- Storage is Azure managed disks (`managed-csi`); shared RWX/Longhorn is not yet wired for Azure, and the page says so.
- Node pools with a required `mode: System` pool, cost notes, and the `azure-config.yaml` starter.

### Local (`local.mdx`)
- Corrects the target: the NIC local provider is **kind (Kubernetes in Docker)**, not k3s. Retitled "Local (kind)".
- Prerequisite is a container runtime (Docker/Podman); `nic` embeds kind, so no separate kind install.
- Self-signed certs, `nebari.local` mapped to the MetalLB gateway IP, auto GitOps repo at `~/.nic/gitops/<project>`, and the `local-config.yaml` starter. Framed as development/testing, not production.

### Support matrix (`index.mdx`)
- Azure and Local moved to Supported; GCP remains planned.

## Source
All provider specifics (example configs, credentials, config-reference anchors, kubeconfig retrieval, mechanics) were taken from `nebari-infrastructure-core` on `main`. Notably, neither Azure nor Local uses the `~/.cache/nic` kubeconfig path (that is Hetzner-specific); both use `nic kubeconfig`.

## Testing
- `npm run build` succeeds; no new broken links or anchors (only pre-existing `/classic/` and `/community/` ones).

## Notes for review
- These providers sit under the repo-wide "under heavy development / not yet production" caveat; the pages read as supported (like AWS/Hetzner, same caveat) but Local is explicitly dev/testing.
- A couple of Local details (exact gateway service name, port specifics) defer to the upstream `docs/local-kind-development.md` guide rather than restating them.