### PR TITLE
Rewrite team structure and decision making for the federated model

### DIFF
--- a/docs/community/decision-making.md
+++ b/docs/community/decision-making.md
@@ -4,12 +4,15 @@ title: Decision making process
 description: Decision making workflows for the Nebari OSS project
 ---
 
-Nebari's [core team][core-team] is the primary decision making authority for the project.
+The Nebari Kubernetes Platform spans many repositories: a stable infrastructure core, the Nebari Operator, and a set of independently developed software packs.
+Decision making is federated to match, and there are **two lanes**.
 
-This group makes decisions about the following non-exhaustive list of items:
+The first covers the overwhelming majority of decisions.
 
-- Major updates to the Nebari project and community, through the Request-for-discussion (RFD) process (see explanation below)
-- Adding and removing members from the [Nebari team following the guidelines][nebari-team]
+| Lane                                            | Who decides                        | When                                                       |
+| ----------------------------------------------- | ---------------------------------- | ---------------------------------------------------------- |
+| [Repository-local](#repository-local-decisions) | That repository's maintainers      | Anything confined to one repository                        |
+| [Platform RFD](#platform-rfds)                  | [Core team][core-team], by consent | Changes that cross repositories or alter a shared contract |
 
 ## Consent-based decision making
 
@@ -23,27 +26,59 @@ In this approach, everyone gets a chance to:
 
 Each objection is discussed and the proposal is updated accordingly. The proposal is accepted when the team reaches a point where there are no objections.
 
-## Major updates - Request-for-discussion (RFD) process
+## Repository-local decisions
 
-New features, sub-projects, and workflow changes that affect a majority of end-users of the core project or the Nebari community, need to follow the Request-for-discussion workflow (sometimes called Enhancement Proposals):
+Anything confined to a single repository is decided by that repository's maintainers, through ordinary issue and pull request review.
 
-1. Open an [RFD-issue in the governance repository][rfd-issue] with your proposal describing the details, benefits, impact, and more as mentioned in the issue template. Add the following labels to the issue: `needs: discussion 💬`, `type: RFD 🗳`
+This includes the repository's features, its dependencies, its release timing, and, for a software pack, its own maturity level.
+No RFD is required, and nothing needs to be routed through the Core team.
+
+Contributors are expected to (informally) follow the consent-based decision making philosophy in these discussions.
+
+## Platform RFDs
+
+A Request-for-discussion is required only for a change that crosses repository boundaries or alters a contract that other repositories depend on:
+
+- the Pack Specification or the `NebariApp` custom resource
+- the single sign-on, routing, or TLS conventions
+- the security baseline
+- the [repository standards][repo-standards]
+- the [pack maturity model][pack-policy]
+- the [project governance][governance] and the policies in the governance repository
+- behavior in the Nebari Infrastructure Core that packs rely on
+
+Adding or removing members of the [Nebari teams][nebari-team] also goes through the Core team, as described on that page.
+
+### The process
+
+1. Open an [RFD-issue in the governance repository][rfd-issue] with your proposal describing the details, benefits, impact, and more as mentioned in the issue template. The template applies the `type: RFD 🗳` and `needs: discussion 💬` labels for you.
 2. Tag the `@nebari-dev/core-team` and any specific people for questions, comments, and objections on your proposal.
 3. Answer questions and update the proposal addressing the objections. If there are major objections, the best course of action is declining the RFD, closing the issue, and opening a new RFD issue with the updated design proposal.
-4. Once all comments are addressed, request the core-team to cast votes. Team members are expected to vote "yes" with a 👍 reaction on the proposal if they have no objection. Votes can also be taken over synchronous community meetings. In this case, the decision is documented with a comment on the RFD issue. Remove the `needs: discussion 💬` label and add `status: being voted 🗳` at this stage.
-5. If over 50% of team members vote "yes", the proposal is accepted. Remove the `status: being voted 🗳` label and add `status: approved 💪🏾`. Do not close the issue yet.
+4. Once all comments are addressed, request the core-team to cast votes. Remove the `needs: discussion 💬` label and add `status: being voted 🗳` at this stage.
+5. If more than 50% of Core team members vote yes, the proposal is accepted. Remove the `status: being voted 🗳` label and add `status: approved 💪🏾`. Do not close the issue yet.
 6. Once the proposal is implemented, close the RFD issue.
 
+Set the **Status** row in the RFD body to match the labels at each step. Each status has exactly one matching label, and an RFD carries exactly one status label at a time. Where the Status row and the labels disagree, the Status row is authoritative and the labels should be corrected. The [canonical table][rfd-lifecycle] lists every status and its label.
+
+### How votes are counted
+
+Spelled out so that anyone can reproduce a tally from the issue itself, months later, without asking who counted what:
+
+- **A yes vote** is a 👍 or ❤️ reaction on the issue from a Core team member. Both count, and each person counts once however many reactions they leave.
+- **Other reactions are not votes.** 👀 in particular is not a vote.
+- **The denominator** is the human membership of the [`core-team`][core-team] GitHub team. Bot accounts in that team are excluded from it. "More than 50%" means strictly more than half, so with ten members it takes six votes, not five.
+- **Where a vote is taken synchronously**, in a community meeting rather than by reaction, the outcome is recorded as a comment on the RFD issue naming the date and who was present. An unrecorded meeting decision cannot be audited afterwards, and is treated as not yet decided.
+
 Learn more in [Gitpod's documentation on decision making][gitpod-rfd].
-
-## Minor updates - Discussion in issues and pull requests
-
-Minor updates to the codebase and documentation can be discussed in GitHub issues or in pull requests during code review. Contributors are expected to (informally) follow the consent-based decision making philosophy in these discussions.
 
 <!-- Reusable links -->
 
 [nebari-team]: /community/team-structure
 [core-team]: https://github.com/orgs/nebari-dev/teams/core-team
 [consent-decision-making]: https://www.sociocracyforall.org/consent-decision-making/
-[rfd-issue]: https://github.com/nebari-dev/governance/issues/new?assignees=&labels=type%3A+RFD&projects=&template=RFD.md&title=RFD+-+Title
+[rfd-issue]: https://github.com/nebari-dev/governance/issues/new?assignees=&labels=type%3A+RFD+%F0%9F%97%B3&projects=&template=RFD.md&title=RFD+-+Title
 [gitpod-rfd]: https://gitpod.notion.site/Decision-Making-RFCs-eb4a57f3a34f40f1afbd95e05322af70
+[governance]: https://github.com/nebari-dev/governance/blob/main/GOVERNANCE.md
+[repo-standards]: https://github.com/nebari-dev/governance/blob/main/repository-standards.md
+[pack-policy]: https://github.com/nebari-dev/governance/blob/main/pack-policy.md
+[rfd-lifecycle]: https://github.com/nebari-dev/governance/blob/main/GOVERNANCE.md#rfd-lifecycle

--- a/docs/community/team-structure.md
+++ b/docs/community/team-structure.md
@@ -11,29 +11,63 @@ This page documents the different teams, their privileges and responsibilities, 
 Use the table of contents in the right sidebar to jump to different sections of this page.
 :::
 
+## How access works
+
+The Nebari Kubernetes Platform is a stable infrastructure core plus a set of independently developed software packs, each in its own repository.
+Authority is federated to match that shape: pack maintainers own their repositories, and a small Core team owns the seams between them.
+
+Two consequences worth stating plainly, because they differ from how the project used to work:
+
+- **Access is granted per repository, following least privilege.** There is no team that carries commit rights across every Nebari repository.
+- **Most decisions never reach Core.** Anything confined to a single repository is decided by that repository's maintainers.
+
+The full model is in the [governance repository](https://github.com/nebari-dev/governance/blob/main/GOVERNANCE.md).
+
 ## Teams
 
 The following teams are formally recognized by Nebari.
 
-### Triage
-
-Members responsible for [triaging](./maintainers/triage-guidelines) and [improving](./file-issues#working-on-issues-to-improve-them) new and existing issues & pull requests (PRs) across all repositories. They can add relevant labels to issues/PRs, edit issue/PR titles and descriptions to improve them, and transfer issues between repositories.
-
-### Contributors
-
-People who make valuable contributions to the Nebari projects in the form of code contributions, documentation improvements, or design enhancements, issues/PR triage, community management, fundraising, advocacy, and more. Members of this team have commit rights across all Nebari repositories, which includes access to [triage](#triage) permissions.
-
 ### Core
 
-Project sustainers who lead and maintain the overall Nebari project and community. They are the core and final decision-makers on project-wide initiatives, and have repository-level management rights across all Nebari projects.
+Project sustainers who lead and maintain the overall Nebari platform and community.
+
+Core owns the cross-cutting contracts, the seams that every repository depends on:
+
+- the Pack Specification and the `NebariApp` custom resource
+- the single sign-on, routing, and TLS conventions
+- the security baseline
+- the [repository standards](https://github.com/nebari-dev/governance/blob/main/repository-standards.md) and the [pack policy](https://github.com/nebari-dev/governance/blob/main/pack-policy.md)
+- the "official pack" designation, and the Nebari trademark and naming rules
+- the platform roadmap, and the final call on platform RFDs
+
+Core does not decide the day-to-day direction of individual repositories. Its mandate is deliberately narrow.
+
+The [`core-team`](https://github.com/orgs/nebari-dev/teams/core-team) GitHub team is the authoritative record of who is on Core, and the size of its human membership sets the threshold for a [platform RFD vote](./decision-making#platform-rfds).
+Keeping it accurate is part of the role.
 
 ### Owners
 
-A private and small subset of the Core team who have organization-level privileges for [`nebari-dev`](https://github.com/nebari-dev). While decisions are made by the entire Core team, the Owners group has relevant permissions to implement certain decision like adding new team members.
+A private and small subset of the Core team who have organization-level privileges for [`nebari-dev`](https://github.com/nebari-dev). While decisions are made by the entire Core team, the Owners group has relevant permissions to implement certain decisions like adding new team members, creating repositories, and applying organization rulesets.
+
+### Pack maintainers
+
+The people who maintain a specific repository, usually a software pack.
+
+Pack maintainers hold write or admin access on **their** repository only, and have full autonomy over its features, releases, dependencies, maturity level, and day-to-day decisions.
+Each repository lists its maintainers in a `MAINTAINERS.md` file, and that file, rather than this page, is the authoritative list for it.
+
+### Contributors
+
+People who make valuable contributions to the Nebari projects in the form of code contributions, documentation improvements, or design enhancements, issues and PR triage, community management, fundraising, advocacy, and more.
+
+Anyone can contribute by opening a pull request; no membership is required.
+Commit and triage access on a given repository is granted by that repository's maintainers as trust is established, as described in [triage and commit access](#triage-and-commit-access) below.
 
 ### Code of Conduct response team
 
 Community members responsible for upholding and enforcing Nebari's Code of Conduct. This team is documented in the [Nebari governance repository](https://github.com/nebari-dev/governance/blob/main/code-of-conduct/coc_enforcement.md#the-code-of-conduct-committee). At least one member of this team should also be in the Nebari Core team, and all members should be trained to handle CoC reports with care[^1].
+
+Its scope is organization-wide. Software packs maintained outside the `nebari-dev` organization are not covered; the Code of Conduct is offered as a recommended default downstream rather than imposed.
 
 [^1]: Members can attend any form of online or in-person training on dealing with CoC reports.
 
@@ -45,11 +79,23 @@ Nebari Core team members can step away at any time, and we hope for them to comm
 
 Emeritus members are welcome return to the project as active participants, and join the core team again through the process of nomination described earlier.
 
-## Special interest or working groups
+## Triage and commit access
 
-In addition to the formal teams, new special interest groups (SIG) can be created with commit and triage access to specific Nebari repositories. In the past, examples of special interest groups are "Documentation" and "Design" teams. The core team is responsible for the approval and dissolution of SIGs.
+[Triaging](./maintainers/triage-guidelines) and [improving](./file-issues#working-on-issues-to-improve-them) issues and pull requests is one of the most useful ways to contribute. Triage access lets you add labels, edit issue and PR titles and descriptions, and transfer issues between repositories.
 
-The Core team can create a new SIG if two or more community members express interest in the [discussion forum](https://github.com/orgs/nebari-dev/discussions/categories/community).
+Triage and commit access are granted **per repository** by that repository's maintainers, as trust is established. There is no standing organization-wide Triage team, and no team that carries commit rights everywhere.
+
+If you have been triaging issues on a repository and would like access, ask its maintainers, either on an issue or in the [discussion forum](https://github.com/orgs/nebari-dev/discussions/categories/community).
+
+:::note
+Members of the previous organization-wide Triage team keep triage access on the repositories they are active in.
+:::
+
+## Working groups
+
+Standing special interest groups (SIGs) are retired as a concept. The pack repository is now the natural working-group unit: a pack has its own repository, its own maintainers, and its own decisions, which is what a SIG used to approximate.
+
+The Core team may still convene an ad-hoc working group for a genuinely cross-cutting topic, such as security or documentation, and dissolve it when the work is done.
 
 ## Join a team
 
@@ -57,24 +103,25 @@ Nebari follows a nomination process to add new team members[^2], as detailed in 
 
 [^2]: All except the [Emeritus core](#emeritus-core) team are decided through nominations.
 
-| Team        | Requirements for nomination                                                                                                                   | Nominators                                                     | Approvers                                                                                             |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Triage      | Engage with (create or comment on) one or more issue/PR/discussion in [`nebari-dev`](https://github.com/nebari-dev)                           | Any community member (including self)                          | Any Core team member                                                                                  |
-| Contributor | Two or more [contributions](/community/introduction/#how-to-contribute) to Nebari with intention to continue contributing regularly           | Any community member (including self)                          | Any Core team member                                                                                  |
-| Core        | [Contributors team](#contributors) member with a record of regular, valuable, and high-quality contributions to Nebari for at least one month | Any community member (including self) and one Core team member | Core team makes a [consent-based decision](https://www.sociocracyforall.org/consent-decision-making/) |
-| Conduct     | Member of the Contributor or Core Team with adequate training to handle CoC reports                                                           | Any community member (including self)                          | Core team makes a [consent-based decision](https://www.sociocracyforall.org/consent-decision-making/) |
+| Team            | Requirements for nomination                                                                                                                                     | Nominators                                                     | Approvers                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Pack maintainer | A record of regular, valuable contributions to that repository, with intention to continue maintaining it                                                       | Any community member (including self)                          | That repository's existing maintainers, or Core for a new repository                                  |
+| Core            | A record of regular, valuable, and high-quality contributions to Nebari for at least one month, and willingness to take responsibility for the platform's seams | Any community member (including self) and one Core team member | Core team makes a [consent-based decision](https://www.sociocracyforall.org/consent-decision-making/) |
+| Conduct         | A contributor or Core team member with adequate training to handle CoC reports                                                                                  | Any community member (including self)                          | Core team makes a [consent-based decision](https://www.sociocracyforall.org/consent-decision-making/) |
 
-Before approving the nomination, Core team members must verify the individual's authenticity and credentials through heuristics like:
+Commit and triage access on a single repository is not a team and does not need a nomination. See [triage and commit access](#triage-and-commit-access).
+
+Before approving the nomination, approvers must verify the individual's authenticity and credentials through heuristics like:
 
 - Checking the nominee's GitHub activity history: account creation date, contributions to other open source projects, etc.
 - Interactions with the nominee in community meetings or conferences.
 - Endorsement from a trusted collaborator.
 
-The Owners team is responsible for updating team memberships on GitHub.
+The Owners team is responsible for updating team memberships on GitHub. For a new pack maintainer, the repository's maintainers can grant repository access directly.
 
 ## Leave a team
 
-Contributors and Core team members may choose to leave their respective teams at any time and for any reason. They can communicate their decision either privately to the Core team or publicly on the Nebari discussion forum.
+Pack maintainers and Core team members may choose to leave their respective teams at any time and for any reason. They can communicate their decision either privately to the Core team or publicly on the Nebari discussion forum.
 
 To ensure project security, the Core team can make a [consent-based decision](https://www.sociocracyforall.org/consent-decision-making/) to remove inactive members from any team. In this context, _inactive_ refers to individuals who have not engaged in any Nebari spaces, such as GitHub repositories under the Nebari organization or community meetings, for a period of over two months.
 


### PR DESCRIPTION
Implements **item 2** of the implementation outline in
[RFD #59](https://github.com/nebari-dev/governance/issues/59), accepted 2026-09-10.

Refs nebari-dev/governance#59

## Why

These two pages describe governance built for **Nebari Classic**: one monolithic platform
in one repository. They grant Contributors "commit rights across all Nebari repositories"
and Core "repository-level management rights across all Nebari projects", and assume every
decision of consequence reaches one central team.

The platform is now a stable infrastructure core plus many independently developed packs,
each in its own repository. Org-wide blanket commit is both a security problem and
meaningless at that shape, and routing every decision through Core reintroduces exactly the
bottleneck the new architecture removed.

## `team-structure.md`

- **Access is per repository.** The org-wide commit claim is gone.
- **Core's mandate is narrowed to the seams**: the Pack Specification, auth/routing/TLS
  conventions, the security baseline, the standards, the official designation, the
  trademark, and platform RFDs. It no longer claims authority over every repository.
- **Pack maintainers** are documented as a role, holding access on their own repository and
  listed in that repository's `MAINTAINERS.md`, which is authoritative rather than this page.
- **Triage becomes a per-repository grant** rather than a standing team, with a note that
  existing Triage members keep access where they are active. Flagging this because the RFD's
  role list omits Triage entirely while the team exists today with real members; this
  follows what the RFD does say about triage being granted per-repo.
- **SIGs are retired**, since a pack repository is now what a SIG approximated. Ad-hoc
  working groups remain available.
- Also notes that the `core-team` GitHub team is the authoritative record of Core membership,
  because its human size is the denominator for an RFD vote.

Deliberately preserved: the nomination process, the identity-verification heuristics, the
leave-a-team process, and the inactivity rule. The RFD does not change any of it, and it is
good material.

## `decision-making.md`

- **Two lanes**, repository-local first because it covers the overwhelming majority of
  decisions. Platform RFD triggers are listed rather than left to judgement.
- **How votes are counted is now written down**: which reactions count, that each person
  counts once however many they leave, that bots are excluded from the denominator, and that
  "more than 50%" means strictly more than half, so ten members takes six votes rather than
  five.
- **A vote taken in a meeting must be recorded on the issue** with the date and who was
  present, or it is treated as not yet decided.

Those last two are not cosmetic. RFD #59 itself reached consent in a meeting that left no
trace on the issue, which made it impossible to record honestly weeks later; and tallying
its vote produced two different answers depending on whether ❤️ counted and who was on
Core. Both gaps are now closed here and in
[`GOVERNANCE.md`](https://github.com/nebari-dev/governance/blob/main/GOVERNANCE.md#platform-rfds).

## Bug fixed along the way

The **RFD issue link pre-filled the wrong label**: `labels=type%3A+RFD`, without the emoji.
No label of that name exists, and GitHub silently drops labels it cannot match, so RFDs
opened from that link arrived unlabelled. Now `type%3A+RFD+%F0%9F%97%B3`.

The same bug existed in the issue template itself and is fixed in
nebari-dev/.github#49.

## Testing

- **`yarn run build` succeeds.** This config sets `onBrokenLinks: "throw"`, so the build is
  a real check on every link I touched, and it passes.
- The build reports pre-existing broken **anchors** in `/classic/how-tos/configuring-keycloak`,
  three `/classic/*` pages that link to it, and
  `/community/maintainers/release-process-branching-strategy`. None are in these two pages,
  and I have left them alone.
- Verified before rewriting that every internal link target these pages use still resolves:
  `./maintainers/triage-guidelines`, `./file-issues#working-on-issues-to-improve-them` (the
  id of `issues.md`), and `/community/introduction/#how-to-contribute`.
- `prettier@3.3.3` run with this repo's `.prettierrc`, so the diff is what `lint-staged`
  would produce at commit time rather than leaving a formatting-only follow-up.
- Page ids are unchanged, so `sidebarsCommunity.js` needs no edit.

## Note for reviewers

These pages now describe teams and process and link to the governance repository for policy,
rather than restating it. That split is deliberate, per the RFD: policy has one home, so the
two cannot drift apart the way the RFD status vocabulary did.
